### PR TITLE
More tinkering with build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project default="create_run_jars" name="Create runnable WhiteRabbit and RabbitInAHat jar files with libraries in sub-folder">
-  <property name="JDK_VERSION" value="1.7" />
-  <path id="classpath">
-    <fileset dir="lib" includes="**/*.jar" />
-  </path>
-  <property name="build.dir" value="bin" />
-  <property name="src.dir" value="src" />
-  <target name="create_run_jars">
-    <delete dir="${build.dir}"/>
-    <mkdir dir="${build.dir}"/>
-    <javac
+	<property name="JDK_VERSION" value="1.7" />
+	<path id="classpath">
+		<fileset dir="lib" includes="**/*.jar" />
+	</path>
+	<property name="build.dir" value="bin" />
+	<property name="src.dir" value="src" />
+	<target name="create_run_jars">
+		<delete dir="${build.dir}"/>
+		<mkdir dir="${build.dir}"/>
+		<javac
       source="${JDK_VERSION}"
       target="${JDK_VERSION}"
       srcdir="${src.dir}"
@@ -19,45 +19,45 @@
       includeantruntime="false"
       />
 
-    <jar destfile="${build.dir}/WhiteRabbit.jar">
-      <manifest>
-        <attribute name="Main-Class" value="org.ohdsi.whiteRabbit.WhiteRabbitMain"/>
-        <attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-${build.dir}.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar"/>
-      </manifest>
-      <fileset dir="${build.dir}"/>
-      <fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
-    </jar>
-    <jar destfile="${build.dir}/RabbitInAHat.jar">
-      <manifest>
-        <attribute name="Main-Class" value="org.ohdsi.rabbitInAHat.RabbitInAHatMain"/>
-        <attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-${build.dir}.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar WhiteRabbit_lib/json-io-3.0.1.jar"/>
-      </manifest>
-      <fileset dir="${build.dir}"/>
-      <fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
-    </jar>
-    <copy todir="${build.dir}">
-      <fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
-    </copy>
-    <delete dir="${build.dir}/WhiteRabbit_lib"/>
-    <mkdir dir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/ojdbc5.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/ojdbc6.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/sqljdbc4.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/mysql-connector-java-5.1.30-${build.dir}.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/dom4j-1.6.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/poi-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/poi-excelant-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/poi-ooxml-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/poi-ooxml-schemas-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/stax-api-1.0.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/xmlbeans-2.3.0.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/jtds-1.2.7.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/postgresql-9.3-1101.jdbc4.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/postgresql-9.3-1101.jdbc41.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="lib/json-io-3.0.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
-    <copy file="scripts/WhiteRabbit1.5GB.cmd" todir="${build.dir}"/>
-    <copy file="scripts/WhiteRabbit1.5GB.sh" todir="${build.dir}"/>
-    <copy file="scripts/RabbitInAHat1.5GB.cmd" todir="${build.dir}"/>
-    <copy file="scripts/RabbitInAHat1.5GB.sh" todir="${build.dir}"/>
-  </target>
+		<jar destfile="${build.dir}/WhiteRabbit.jar">
+			<manifest>
+				<attribute name="Main-Class" value="org.ohdsi.whiteRabbit.WhiteRabbitMain"/>
+				<attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-${build.dir}.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar"/>
+			</manifest>
+			<fileset dir="${build.dir}"/>
+			<fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
+		</jar>
+		<jar destfile="${build.dir}/RabbitInAHat.jar">
+			<manifest>
+				<attribute name="Main-Class" value="org.ohdsi.rabbitInAHat.RabbitInAHatMain"/>
+				<attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-${build.dir}.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar WhiteRabbit_lib/json-io-3.0.1.jar"/>
+			</manifest>
+			<fileset dir="${build.dir}"/>
+			<fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
+		</jar>
+		<copy todir="${build.dir}">
+			<fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
+		</copy>
+		<delete dir="${build.dir}/WhiteRabbit_lib"/>
+		<mkdir dir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/ojdbc5.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/ojdbc6.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/sqljdbc4.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/mysql-connector-java-5.1.30-${build.dir}.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/dom4j-1.6.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/poi-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/poi-excelant-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/poi-ooxml-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/poi-ooxml-schemas-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/stax-api-1.0.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/xmlbeans-2.3.0.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/jtds-1.2.7.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/postgresql-9.3-1101.jdbc4.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/postgresql-9.3-1101.jdbc41.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="lib/json-io-3.0.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+		<copy file="scripts/WhiteRabbit1.5GB.cmd" todir="${build.dir}"/>
+		<copy file="scripts/WhiteRabbit1.5GB.sh" todir="${build.dir}"/>
+		<copy file="scripts/RabbitInAHat1.5GB.cmd" todir="${build.dir}"/>
+		<copy file="scripts/RabbitInAHat1.5GB.sh" todir="${build.dir}"/>
+	</target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -1,61 +1,63 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project default="create_run_jars" name="Create runnable WhiteRabbit and RabbitInAHat jar files with libraries in sub-folder">
-  <!--this file was created by Eclipse Runnable JAR Export Wizard-->
-  <!--ANT 1.7 is required                                        -->
+  <property name="JDK_VERSION" value="1.7" />
+  <path id="classpath">
+    <fileset dir="lib" includes="**/*.jar" />
+  </path>
+  <property name="build.dir" value="bin" />
+  <property name="src.dir" value="src" />
   <target name="create_run_jars">
-    <property name="JDK_VERSION" value="1.7" />
-    <path id="classpath">
-      <fileset dir="lib" includes="**/*.jar" />
-    </path>
-    <delete dir="dist"/>
-    <mkdir dir="dist"/>
-    <delete dir="bin"/>
-    <mkdir dir="bin"/>
+    <delete dir="${build.dir}"/>
+    <mkdir dir="${build.dir}"/>
     <javac
       source="${JDK_VERSION}"
       target="${JDK_VERSION}"
-      srcdir="src"
+      srcdir="${src.dir}"
+      debug="true"
       classpathref="classpath"
-      destdir="bin"
+      destdir="${build.dir}"
       includeantruntime="false"
       />
 
-    <jar destfile="dist/WhiteRabbit.jar">
+    <jar destfile="${build.dir}/WhiteRabbit.jar">
       <manifest>
         <attribute name="Main-Class" value="org.ohdsi.whiteRabbit.WhiteRabbitMain"/>
-        <attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-bin.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar"/>
+        <attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-${build.dir}.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar"/>
       </manifest>
-      <fileset dir="bin"/>
-      <fileset dir="src" includes="**/*.csv,**/*.png" />	
+      <fileset dir="${build.dir}"/>
+      <fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
     </jar>
-    <jar destfile="dist/RabbitInAHat.jar">
+    <jar destfile="${build.dir}/RabbitInAHat.jar">
       <manifest>
         <attribute name="Main-Class" value="org.ohdsi.rabbitInAHat.RabbitInAHatMain"/>
-        <attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-bin.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar WhiteRabbit_lib/json-io-3.0.1.jar"/>
+        <attribute name="Class-Path" value=". WhiteRabbit_lib/ojdbc5.jar WhiteRabbit_lib/ojdbc6.jar WhiteRabbit_lib/sqljdbc4.jar WhiteRabbit_lib/mysql-connector-java-5.1.30-${build.dir}.jar WhiteRabbit_lib/dom4j-1.6.1.jar WhiteRabbit_lib/poi-3.9-20121203.jar WhiteRabbit_lib/poi-excelant-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-3.9-20121203.jar WhiteRabbit_lib/poi-ooxml-schemas-3.9-20121203.jar WhiteRabbit_lib/stax-api-1.0.1.jar WhiteRabbit_lib/xmlbeans-2.3.0.jar WhiteRabbit_lib/jtds-1.2.7.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc4.jar WhiteRabbit_lib/postgresql-9.3-1101.jdbc41.jar WhiteRabbit_lib/json-io-3.0.1.jar"/>
       </manifest>
-      <fileset dir="bin"/>
-      <fileset dir="src" includes="**/*.csv,**/*.png" />	
+      <fileset dir="${build.dir}"/>
+      <fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
     </jar>
-    <delete dir="dist/WhiteRabbit_lib"/>
-    <mkdir dir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/ojdbc5.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/ojdbc6.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/sqljdbc4.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/mysql-connector-java-5.1.30-bin.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/dom4j-1.6.1.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/poi-3.9-20121203.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/poi-excelant-3.9-20121203.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/poi-ooxml-3.9-20121203.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/poi-ooxml-schemas-3.9-20121203.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/stax-api-1.0.1.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/xmlbeans-2.3.0.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/jtds-1.2.7.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/postgresql-9.3-1101.jdbc4.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/postgresql-9.3-1101.jdbc41.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="lib/json-io-3.0.1.jar" todir="dist/WhiteRabbit_lib"/>
-    <copy file="scripts/WhiteRabbit1.5GB.cmd" todir="dist"/>
-    <copy file="scripts/WhiteRabbit1.5GB.sh" todir="dist"/>
-    <copy file="scripts/RabbitInAHat1.5GB.cmd" todir="dist"/>
-    <copy file="scripts/RabbitInAHat1.5GB.sh" todir="dist"/>
+    <copy todir="${build.dir}">
+      <fileset dir="${src.dir}" includes="**/*.csv,**/*.png" />
+    </copy>
+    <delete dir="${build.dir}/WhiteRabbit_lib"/>
+    <mkdir dir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/ojdbc5.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/ojdbc6.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/sqljdbc4.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/mysql-connector-java-5.1.30-${build.dir}.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/dom4j-1.6.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/poi-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/poi-excelant-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/poi-ooxml-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/poi-ooxml-schemas-3.9-20121203.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/stax-api-1.0.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/xmlbeans-2.3.0.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/jtds-1.2.7.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/postgresql-9.3-1101.jdbc4.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/postgresql-9.3-1101.jdbc41.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="lib/json-io-3.0.1.jar" todir="${build.dir}/WhiteRabbit_lib"/>
+    <copy file="scripts/WhiteRabbit1.5GB.cmd" todir="${build.dir}"/>
+    <copy file="scripts/WhiteRabbit1.5GB.sh" todir="${build.dir}"/>
+    <copy file="scripts/RabbitInAHat1.5GB.cmd" todir="${build.dir}"/>
+    <copy file="scripts/RabbitInAHat1.5GB.sh" todir="${build.dir}"/>
   </target>
 </project>


### PR DESCRIPTION
My coworker and I were having inconsistent experiences when trying to build/debug/run Rabbit in a Hat, particularly when running debug mode.

We finally tracked it down to Eclipse running RiaH in bin/* where as dist/* was the directory that was  populated with all the correct files after running a successful build.  Because bin/* ended up missing crucial CSV files, the debug run of RiaH would bomb out.

I added debug="true" to the javac task to get debugging symbols into the programs, then reworked the build.xml file to use bin/* for both debug and normal builds.

I'm still no expert in ant and this build.xml file is still very broken, but at least my coworker and I now have the ability to build/run/debug in both of our differing environments.