### PR TITLE
Allows multiple selection of boxes and automatic mappings between them

### DIFF
--- a/src/org/ohdsi/rabbitInAHat/Arrow.java
+++ b/src/org/ohdsi/rabbitInAHat/Arrow.java
@@ -202,4 +202,8 @@ public class Arrow implements MappingComponent {
 	public boolean isSourceAndTargetVisible(){
 		return source.isVisible() && target.isVisible();
 	}
+	
+	public boolean isConnected(){
+		return source != null && target != null;
+	}
 }

--- a/src/org/ohdsi/rabbitInAHat/Arrow.java
+++ b/src/org/ohdsi/rabbitInAHat/Arrow.java
@@ -161,10 +161,6 @@ public class Arrow implements MappingComponent {
 	public Color fillColor() {
 		return getHighlightStatus().color;
 	}
-	
-	public boolean isHighlighted() {
-		return isSourceSelected() || isTargetSelected();
-	}
 
 	private boolean isTargetSelected() {
 		return target != null && target.isSelected();

--- a/src/org/ohdsi/rabbitInAHat/Arrow.java
+++ b/src/org/ohdsi/rabbitInAHat/Arrow.java
@@ -26,11 +26,22 @@ import java.awt.Polygon;
 
 public class Arrow implements MappingComponent {
 
+	public enum HighlightStatus {
+		BOTH_SELECTED (new Color(255, 255, 0, 192)),
+		SOURCE_SELECTED (new Color(255, 128, 0, 192)),
+		TARGET_SELECTED (new Color(0, 0, 255, 192)),
+		NONE_SELECTED (new Color(128, 128, 128, 128));
+		
+		private final Color color;
+		
+		HighlightStatus(Color color) {
+			this.color = color;
+		}
+	}
+	
 	public static float			thickness		= 5;
 	public static int			headThickness	= 15;
-	public static Color			color	    	= new Color(128, 128, 128, 128);
-	public static Color			sourceColor		= new Color(255, 128, 0, 192);
-	public static Color			targetColor		= new Color(0, 0, 255, 192);
+	public static Color			color	    	= HighlightStatus.NONE_SELECTED.color;
 	private static BasicStroke	dashed			= new BasicStroke(2.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, new float[] { 10.f }, 0.0f);
 
 	private int					x1;
@@ -46,7 +57,7 @@ public class Arrow implements MappingComponent {
 	private Polygon				polygon;
 
 	private boolean				isSelected		= false;
-	private boolean				isVisible		= true;																										;
+	private boolean				isVisible		= true;
 
 	public Arrow(LabeledRectangle source) {
 		this.source = source;
@@ -148,17 +159,19 @@ public class Arrow implements MappingComponent {
 	}
 
 	public Color fillColor() {
-		if (source != null && source.isSelected()) {
-			return sourceColor;
-		} else if (target != null && target.isSelected()) {
-			return targetColor;
-		} else {
-			return color;
-		}
+		return getHighlightStatus().color;
 	}
 	
 	public boolean isHighlighted() {
-		return (source != null && source.isSelected()) || (target != null && target.isSelected());
+		return isSourceSelected() || isTargetSelected();
+	}
+
+	private boolean isTargetSelected() {
+		return target != null && target.isSelected();
+	}
+
+	private boolean isSourceSelected() {
+		return source != null && source.isSelected();
 	}
 
 	public static void drawArrowHead(Graphics2D g2d, int x, int y) {
@@ -183,10 +196,22 @@ public class Arrow implements MappingComponent {
 		return target;
 	}
 
+	public HighlightStatus getHighlightStatus() {
+		if (isSourceSelected() && isTargetSelected()) {
+			return HighlightStatus.BOTH_SELECTED;
+		} else if (isSourceSelected()) {
+			return HighlightStatus.SOURCE_SELECTED;
+		} else if (isTargetSelected()) {
+			return HighlightStatus.TARGET_SELECTED;
+		} else {
+			return HighlightStatus.NONE_SELECTED;
+		}
+	}
+
 	public boolean isSelected() {
 		return isSelected;
 	}
-
+	
 	public void setSelected(boolean isSelected) {
 		this.isSelected = isSelected;
 	}

--- a/src/org/ohdsi/rabbitInAHat/FilterDialog.java
+++ b/src/org/ohdsi/rabbitInAHat/FilterDialog.java
@@ -33,7 +33,7 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 	
 	public FilterDialog(Window parentWindow){
 		
-		super(parentWindow,"Filter Results",ModalityType.MODELESS);		
+		super(parentWindow,"Filter",ModalityType.MODELESS);		
 						
 		this.setLocation(parentWindow.getX()+parentWindow.getWidth()/2, parentWindow.getY()+100);
 		this.setSize(700,120);
@@ -95,6 +95,8 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 		if (filterPanel != null) {
 			aFilterPanel.addResizeListener(this);
 		}
+		
+		setSearchFieldsToLastSearch();
 	}
 	
 	public MappingPanel getFilterPanel(){
@@ -134,9 +136,12 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 		doFilterPanel("","Source");
 	}
 	
+	private void setSearchFieldsToLastSearch(){
+		sourceSearchField.setText(getFilterPanel().getLastSourceFilter());			
+		targetSearchField.setText(getFilterPanel().getLastTargetFilter());
+	}
 	public void notifyResized(int height, boolean minimized, boolean maximized) {
-		clearSourceFilter();
-		clearTargetFilter();
+		setSearchFieldsToLastSearch();
 	}
 	
 	class SearchListener implements KeyListener{

--- a/src/org/ohdsi/rabbitInAHat/LabeledRectangle.java
+++ b/src/org/ohdsi/rabbitInAHat/LabeledRectangle.java
@@ -186,6 +186,11 @@ public class LabeledRectangle implements MappingComponent {
 	public void setSelected(boolean isSelected) {
 		this.isSelected = isSelected;
 	}
+	
+	public boolean toggleSelected(){
+		this.isSelected = !this.isSelected;
+		return isSelected;
+	}
 
 	public void setVisible(boolean value) {
 		isVisible = value;

--- a/src/org/ohdsi/rabbitInAHat/LabeledRectangle.java
+++ b/src/org/ohdsi/rabbitInAHat/LabeledRectangle.java
@@ -161,6 +161,11 @@ public class LabeledRectangle implements MappingComponent {
 	public boolean contains(Point point) {
 		return (point.x >= x && point.x <= x + width && point.y >= y && point.y <= y + height);
 	}
+	
+	public boolean contains(Point point, int xOffset, int yOffset) {
+		Point p = new Point(point.x + xOffset, point.y + yOffset);
+		return contains(p);
+	}
 
 	public int getX() {
 		return x;

--- a/src/org/ohdsi/rabbitInAHat/LabeledRectangle.java
+++ b/src/org/ohdsi/rabbitInAHat/LabeledRectangle.java
@@ -86,10 +86,11 @@ public class LabeledRectangle implements MappingComponent {
 	}
 	
 	public void filter(String searchTerm){
-		if (this.getItem().getName().matches(".*" + searchTerm + ".*") || searchTerm.equals("") ){
+		if (this.getItem().getName().matches(".*(" + searchTerm + ").*") || searchTerm.equals("") ){
 			this.setVisible(true);				
 		}else{
 			this.setVisible(false);
+			this.setSelected(false);
 		}
 	}
 	

--- a/src/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/src/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -36,6 +36,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.AbstractAction;
@@ -327,8 +328,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				component.setSelected(false);
 			}
 		}
-		
-		if (event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH) { // Source component
+		if (event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH) { // Source component		
 			LabeledRectangleClicked(event, getVisibleSourceComponents());
 		}
 		
@@ -743,6 +743,28 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			
 			mapping.addSourceToCdmMap(source.getItem(), target.getItem());
 		}
+		repaint();
+	}
+	
+	public void removeMapSelectedSourceAndTarget(){
+			
+		for( LabeledRectangle source : getSelectedRectangles(sourceComponents)){			
+			for(LabeledRectangle target :  getSelectedRectangles(targetComponents)){
+				removeMapSourceToTarget(source,target);
+			}
+		}			
+	}
+
+	private void removeMapSourceToTarget(LabeledRectangle source, LabeledRectangle target){	
+		
+		for (Iterator<Arrow> iterator = arrows.iterator(); iterator.hasNext();){
+			Arrow arrow = iterator.next();
+			if (source == arrow.getSource() && target == arrow.getTarget()){
+				iterator.remove();
+			}
+		}
+		
+		mapping.removeSourceToCdmMap(source.getItem(), target.getItem());
 		repaint();
 	}
 	

--- a/src/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/src/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -34,7 +34,6 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -284,7 +283,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			if (component != dragRectangle)
 				component.paint(g2d);
 
-		for (int i = HighlightStatus.values().length - 1; i <= 0; i--) {
+		for (int i = HighlightStatus.values().length - 1; i >= 0; i--) {
 			HighlightStatus status = HighlightStatus.values()[i];
 			for (Arrow arrow: arrowsByStatus(status)) {
 				if (arrow != dragArrow) {
@@ -298,10 +297,6 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 
 		if (dragArrow != null)
 			dragArrow.paint(g2d);
-		
-		for (Arrow component : highlightedArrows())
-			if (component != dragArrow)
-				component.paint(g2d);
 		
 		if (offscreen != null)
 			g.drawImage(offscreen, 0, 0, this);
@@ -641,16 +636,6 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	
 	public void setDetailsListener(DetailsListener detailsListener) {
 		this.detailsListener = detailsListener;
-	}
-	
-	private List<Arrow> highlightedArrows() {
-		List<Arrow> highlighted = new ArrayList<Arrow>();
-		for(Arrow arrow : arrows) {
-			if (arrow.isHighlighted()) {
-				highlighted.add(arrow);
-			}
-		}
-		return highlighted;
 	}
 	
 	private void removeArrow(Arrow a){

--- a/src/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/src/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -84,6 +84,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	private MappingPanel			slaveMappingPanel;
 	private boolean					showOnlyConnectedItems		= false;
 
+	private String					lastSourceFilter			= "";
+	private String					lastTargetFilter			= "";
+
 	private boolean					showingArrowStarts			= false;
 
 	private DetailsListener			detailsListener;
@@ -109,6 +112,14 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		});
 		
 		renderModel();
+	}
+	
+	public String getLastSourceFilter(){
+		return lastSourceFilter;
+	}
+	
+	public String getLastTargetFilter(){
+		return lastTargetFilter;
 	}
 	
 	public boolean isMinimized(){
@@ -238,8 +249,10 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		
 		if( filterTarget == true ){
 			components = targetComponents;
+			lastTargetFilter = searchTerm;
 		}else{
 			components = sourceComponents;
+			lastSourceFilter = searchTerm;
 		}
 		
 		for (LabeledRectangle c : components){	
@@ -335,13 +348,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		}
 		if (event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH) { // Source component		
 			LabeledRectangleClicked(event, getVisibleSourceComponents());
-		}
-		
-		if (event.getX() > cdmX && event.getX() < cdmX + ITEM_WIDTH) { // cdm component
+		}else if (event.getX() > cdmX && event.getX() < cdmX + ITEM_WIDTH) { // cdm component
 			LabeledRectangleClicked(event,  getVisibleTargetComponents());
-		}
-		
-		if (event.getX() > sourceX + ITEM_WIDTH && event.getX() < cdmX) { // Arrows
+		}else if (event.getX() > sourceX + ITEM_WIDTH && event.getX() < cdmX) { // Arrows
 			Arrow clickedArrow = null;
 			for (HighlightStatus status: HighlightStatus.values()) {
 				for (Arrow arrow : currentArrowStatus.get(status)) {
@@ -362,6 +371,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 						slaveMappingPanel.setMapping(ObjectExchange.etl.getFieldToFieldMapping((Table) zoomArrow.getSource().getItem(), (Table) zoomArrow
 								.getTarget().getItem()));
 						new AnimateThread(true).start();
+						
+						slaveMappingPanel.filterComponents("", false);
+						slaveMappingPanel.filterComponents("", true);
 					}
 
 				} else { // single click
@@ -372,7 +384,11 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 					}
 					repaint();
 				}
+			}else{
+				detailsListener.showDetails(null);
 			}
+		}else{
+			detailsListener.showDetails(null);
 		}
 
 	}
@@ -466,11 +482,10 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		minimized = false;
 		for (ResizeListener resizeListener : resizeListeners)
 			resizeListener.notifyResized(maxHeight, false, true);
-		for (LabeledRectangle component : sourceComponents)
-			component.setVisible(true);
 
-		for (LabeledRectangle component : targetComponents)
-			component.setVisible(true);
+		filterComponents(lastSourceFilter, false);
+		
+		filterComponents(lastTargetFilter, true);
 
 		for (Arrow component : arrows)
 			component.setVisible(true);

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -300,6 +300,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 				break;
 			case ACTION_CMD_FILTER:
 				doOpenFilterDialog();
+				break;
 			case ACTION_CMD_MAKE_MAPPING:
 				doMakeMappings();
 				break;

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -114,7 +114,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		tableMappingPanel.setDetailsListener(detailsPanel);
 		fieldMappingPanel.setDetailsListener(detailsPanel);
 		JSplitPane leftRightSplinePane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableFieldSplitPane, detailsPanel);
-		leftRightSplinePane.setDividerLocation(700);
+		leftRightSplinePane.setResizeWeight(0.40);
 		frame.add(leftRightSplinePane);
 		
 		loadIcons(frame);
@@ -194,20 +194,19 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		JMenuItem filter = new JMenuItem(ACTION_CMD_FILTER);
 		filter.addActionListener(this);
 		filter.setActionCommand(ACTION_CMD_FILTER);
+		filter.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, ActionEvent.CTRL_MASK));	
 		editMenu.add(filter);
 
 		JMenuItem makeMappings = new JMenuItem(ACTION_CMD_MAKE_MAPPING);
 		makeMappings.addActionListener(this);
 		makeMappings.setActionCommand(ACTION_CMD_MAKE_MAPPING);
-		makeMappings.setAccelerator(KeyStroke.getKeyStroke(
-                KeyEvent.VK_M, ActionEvent.CTRL_MASK));		
+		makeMappings.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, ActionEvent.CTRL_MASK));		
 		editMenu.add(makeMappings);
 
 		JMenuItem removeMappings = new JMenuItem(ACTION_CMD_REMOVE_MAPPING);
 		removeMappings.addActionListener(this);
 		removeMappings.setActionCommand(ACTION_CMD_REMOVE_MAPPING);
-		removeMappings.setAccelerator(KeyStroke.getKeyStroke(
-                KeyEvent.VK_R, ActionEvent.CTRL_MASK));		
+		removeMappings.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.CTRL_MASK));		
 		editMenu.add(removeMappings);
 		
 		// JMenu viewMenu = new JMenu("View");

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -53,7 +53,8 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 	public final static String		ACTION_CMD_GENERATE_ETL_DOCUMENT	= "Generate ETL Document";
 	public final static String		ACTION_CMD_DISCARD_COUNTS			= "Discard value counts";
 	public final static String		ACTION_CMD_FILTER					= "Filter";
-
+	public final static String		ACTION_CMD_MAKE_MAPPING				= "Make Mappings";
+	
 	private final static FileFilter	FILE_FILTER_GZ					= new FileNameExtensionFilter("GZIP Files (*.gz)", "gz");
 	private final static FileFilter	FILE_FILTER_DOCX					= new FileNameExtensionFilter("Microsoft Word documents (*.docx)", "docx");
 	private JFrame					frame;
@@ -114,7 +115,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		JSplitPane leftRightSplinePane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableFieldSplitPane, detailsPanel);
 		leftRightSplinePane.setDividerLocation(700);
 		frame.add(leftRightSplinePane);
-
+		
 		loadIcons(frame);
 		frame.pack();
 		frame.setExtendedState(java.awt.Frame.MAXIMIZED_BOTH);
@@ -193,6 +194,14 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		filter.addActionListener(this);
 		filter.setActionCommand(ACTION_CMD_FILTER);
 		editMenu.add(filter);
+
+		JMenuItem makeMappings = new JMenuItem(ACTION_CMD_MAKE_MAPPING);
+		makeMappings.addActionListener(this);
+		makeMappings.setActionCommand(ACTION_CMD_MAKE_MAPPING);
+		makeMappings.setAccelerator(KeyStroke.getKeyStroke(
+                KeyEvent.VK_M, ActionEvent.CTRL_MASK));
+		
+		editMenu.add(makeMappings);
 
 		// JMenu viewMenu = new JMenu("View");
 		// menuBar.add(viewMenu);
@@ -284,6 +293,8 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 				break;
 			case ACTION_CMD_FILTER:
 				doOpenFilterDialog();
+			case ACTION_CMD_MAKE_MAPPING:
+				doMakeMappings();
 				break;
 		}
 	}
@@ -296,6 +307,15 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		filter.setFilterPanel(tableMappingPanel);
 				
 		filter.setVisible(true);
+	}
+
+	private void doMakeMappings() {
+		if(this.tableMappingPanel.isMaximized()){
+			this.tableMappingPanel.makeMapSelectedSourceAndTarget();
+		}else{
+			this.fieldMappingPanel.makeMapSelectedSourceAndTarget();
+		}
+		
 	}
 
 	private void doDiscardCounts() {

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -54,6 +54,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 	public final static String		ACTION_CMD_DISCARD_COUNTS			= "Discard value counts";
 	public final static String		ACTION_CMD_FILTER					= "Filter";
 	public final static String		ACTION_CMD_MAKE_MAPPING				= "Make Mappings";
+	public final static String		ACTION_CMD_REMOVE_MAPPING			= "Remove Mappings";
 	
 	private final static FileFilter	FILE_FILTER_GZ					= new FileNameExtensionFilter("GZIP Files (*.gz)", "gz");
 	private final static FileFilter	FILE_FILTER_DOCX					= new FileNameExtensionFilter("Microsoft Word documents (*.docx)", "docx");
@@ -199,10 +200,16 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		makeMappings.addActionListener(this);
 		makeMappings.setActionCommand(ACTION_CMD_MAKE_MAPPING);
 		makeMappings.setAccelerator(KeyStroke.getKeyStroke(
-                KeyEvent.VK_M, ActionEvent.CTRL_MASK));
-		
+                KeyEvent.VK_M, ActionEvent.CTRL_MASK));		
 		editMenu.add(makeMappings);
 
+		JMenuItem removeMappings = new JMenuItem(ACTION_CMD_REMOVE_MAPPING);
+		removeMappings.addActionListener(this);
+		removeMappings.setActionCommand(ACTION_CMD_REMOVE_MAPPING);
+		removeMappings.setAccelerator(KeyStroke.getKeyStroke(
+                KeyEvent.VK_R, ActionEvent.CTRL_MASK));		
+		editMenu.add(removeMappings);
+		
 		// JMenu viewMenu = new JMenu("View");
 		// menuBar.add(viewMenu);
 
@@ -296,6 +303,9 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 			case ACTION_CMD_MAKE_MAPPING:
 				doMakeMappings();
 				break;
+			case ACTION_CMD_REMOVE_MAPPING:
+				doRemoveMappings();
+				break;
 		}
 	}
 	
@@ -318,6 +328,14 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		
 	}
 
+	private void doRemoveMappings() {
+		if(this.tableMappingPanel.isMaximized()){
+			this.tableMappingPanel.removeMapSelectedSourceAndTarget();
+		}else{
+			this.fieldMappingPanel.removeMapSelectedSourceAndTarget();
+		}
+		
+	}
 	private void doDiscardCounts() {
 		ObjectExchange.etl.discardCounts();
 		detailsPanel.refresh();


### PR DESCRIPTION
This allows user to select multiple boxes from both the source and target and create mappings between them.  

Multiple boxes can be selected using Ctrl+left mouse click which adds to the selection one per click.  A range of boxes can also be selected by selecting one box then Shift+ left mouse click a box below or above to select the range between them.  

Once boxes are selected from both the source and target going to Edit>Make Mappings or pressing Ctrl+M will automatically map all selected items.  Mappings can be removed in a similar fashion by going to Edit>Remove Mappings or pressing Ctrl+R.

This resolves #38.  