### PR TITLE
The split between table and detail panes inconsistently resizes

### DIFF
--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -111,6 +111,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		detailsPanel = new DetailsPanel();
 		detailsPanel.setBorder(new TitledBorder("Details"));
 		detailsPanel.setPreferredSize(new Dimension(200, 500));
+		detailsPanel.setMinimumSize(new Dimension(0, 0));
 		tableMappingPanel.setDetailsListener(detailsPanel);
 		fieldMappingPanel.setDetailsListener(detailsPanel);
 		JSplitPane leftRightSplinePane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, tableFieldSplitPane, detailsPanel);


### PR DESCRIPTION
Sometimes the table pane could not be resized far enough to the right to allow me to completely see all tables.

I found this article: https://docs.oracle.com/javase/tutorial/uiswing/components/splitpane.html#divider which suggested setting the minimum size on at least one of the panels.  Following this advice fixed my issues with resizing.