### PR TITLE
Fix selecting arrows

### DIFF
--- a/src/org/ohdsi/rabbitInAHat/Arrow.java
+++ b/src/org/ohdsi/rabbitInAHat/Arrow.java
@@ -27,6 +27,7 @@ import java.awt.Polygon;
 public class Arrow implements MappingComponent {
 
 	public enum HighlightStatus {
+		IS_SELECTED (new Color(128, 128, 128, 128)),
 		BOTH_SELECTED (new Color(255, 255, 0, 192)),
 		SOURCE_SELECTED (new Color(255, 128, 0, 192)),
 		TARGET_SELECTED (new Color(0, 0, 255, 192)),
@@ -193,7 +194,9 @@ public class Arrow implements MappingComponent {
 	}
 
 	public HighlightStatus getHighlightStatus() {
-		if (isSourceSelected() && isTargetSelected()) {
+		if (isSelected()) {
+			return HighlightStatus.IS_SELECTED;
+		} else if (isSourceSelected() && isTargetSelected()) {
 			return HighlightStatus.BOTH_SELECTED;
 		} else if (isSourceSelected()) {
 			return HighlightStatus.SOURCE_SELECTED;


### PR DESCRIPTION
Even though I was drawing highlighted arrows on top of other arrows, it seems that once an arrow receives a single click, all arrows go back to being completely unhighlighted and we revert back to drawing arrows on top of each other in an arbitrary manner.

This caused a problem with double-clicking highlighted arrows because the first click will cause the arrow to no longer be highlighted and the second click might land on a different arrow because the original arrow of interest has been buried now that it is no longer highlighted.

I added a category to highlight status, "IS_SELECTED" and now a selected arrow is always drawn last, making it sit on top of all other arrows.  So the first click now raises an arrow to the top of the stack, making it a prime target for that second click.