### PR TITLE
Keeps source to target mappings between tables/fields when switching DB's (schema's)

### DIFF
--- a/src/org/ohdsi/rabbitInAHat/ETLDocumentGenerator.java
+++ b/src/org/ohdsi/rabbitInAHat/ETLDocumentGenerator.java
@@ -20,12 +20,9 @@ package org.ohdsi.rabbitInAHat;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.util.zip.GZIPInputStream;
 
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.xwpf.usermodel.BreakType;
@@ -43,14 +40,6 @@ import org.ohdsi.rabbitInAHat.dataModel.Mapping;
 import org.ohdsi.rabbitInAHat.dataModel.Table;
 
 public class ETLDocumentGenerator {
-	public static void main(String[] args) throws IOException, ClassNotFoundException {
-		FileInputStream fileOutputStream = new FileInputStream("C:/home/Research/EMIF WP12/HCUP//HCUP_final.etl");
-		GZIPInputStream gzipOutputStream = new GZIPInputStream(fileOutputStream);
-		ObjectInputStream out = new ObjectInputStream(gzipOutputStream);
-		ETL etl = (ETL) out.readObject();
-		out.close();
-		generate(etl, "C:/Users/mschuemi/Desktop/test.docx");
-	}
 	
 	public static void generate(ETL etl, String filename, boolean includeCounts) {
 		try {
@@ -226,13 +215,13 @@ public class ETLDocumentGenerator {
 		XWPFParagraph tmpParagraph = document.createParagraph();
 		XWPFRun tmpRun = tmpParagraph.createRun();
 		
-		tmpRun.setText("Source Data Mapping Approach");
-		tmpRun.setFontSize(18);
-		
 		MappingPanel mappingPanel = new MappingPanel(etl.getTableToTableMapping());
 		mappingPanel.setShowOnlyConnectedItems(true);
 		int height = mappingPanel.getMinimumSize().height;
 		mappingPanel.setSize(800, height);
+		
+		tmpRun.setText(mappingPanel.getSourceDbName() + " Data Mapping Approach to " + mappingPanel.getTargetDbName());
+		tmpRun.setFontSize(18);
 		
 		BufferedImage im = new BufferedImage(800, height, BufferedImage.TYPE_INT_ARGB);
 		im.getGraphics().setColor(Color.WHITE);

--- a/src/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/src/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -278,7 +278,8 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		
 		RenderingHints rh = new RenderingHints(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g2d.setRenderingHints(rh); 
-
+		
+		g2d.setColor(Color.BLACK);
 		addLabel(g2d, this.getSourceDbName(), sourceX + ITEM_WIDTH / 2, HEADER_TOP_MARGIN + HEADER_HEIGHT / 2);
 		addLabel(g2d, this.getTargetDbName(), cdmX + ITEM_WIDTH / 2, HEADER_TOP_MARGIN + HEADER_HEIGHT / 2);
 		

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -58,9 +58,11 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 	public final static String		ACTION_CMD_REMOVE_MAPPING			= "Remove Mappings";
 	public final static String		ACTION_CMD_SET_TARGET_V4			= "CDM v4";
 	public final static String		ACTION_CMD_SET_TARGET_V5			= "CDM v5";
+	public final static String		ACTION_CMD_SET_TARGET_CUSTOM		= "Load Target";
 	
 	private final static FileFilter	FILE_FILTER_GZ					= new FileNameExtensionFilter("GZIP Files (*.gz)", "gz");
 	private final static FileFilter	FILE_FILTER_DOCX					= new FileNameExtensionFilter("Microsoft Word documents (*.docx)", "docx");
+	private final static FileFilter	FILE_FILTER_CSV					= new FileNameExtensionFilter("Text Files (*.csv)", "csv");
 	private JFrame					frame;
 	private JScrollPane				scrollPane1;
 	private JScrollPane				scrollPane2;
@@ -215,6 +217,13 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		editMenu.add(removeMappings);
 		
 		JMenu setTarget = new JMenu("Set Target Database");
+				
+		JMenuItem loadTarget = new JMenuItem(ACTION_CMD_SET_TARGET_CUSTOM);
+		loadTarget.addActionListener(this);
+		loadTarget.setActionCommand(ACTION_CMD_SET_TARGET_CUSTOM);
+		setTarget.add(loadTarget);		
+		editMenu.add(setTarget);
+		
 		JMenuItem targetCDMV4 = new JMenuItem(ACTION_CMD_SET_TARGET_V4);
 		targetCDMV4.addActionListener(this);
 		targetCDMV4.setActionCommand(ACTION_CMD_SET_TARGET_V4);
@@ -226,7 +235,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		targetCDMV5.setActionCommand(ACTION_CMD_SET_TARGET_V5);
 		setTarget.add(targetCDMV5);		
 		editMenu.add(setTarget);
-		
+
 		// JMenu viewMenu = new JMenu("View");
 		// menuBar.add(viewMenu);
 
@@ -330,9 +339,21 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 			case ACTION_CMD_SET_TARGET_V5:
 				doSetTargetCDM(CDMVersion.CDMV5);
 				break;
+			case ACTION_CMD_SET_TARGET_CUSTOM:
+				doSetTargetCustom(chooseOpenPath(FILE_FILTER_CSV));
+				break;
 		}
 	}
 	
+	private void doSetTargetCustom(String fileName) {
+		ETL etl = new ETL(ObjectExchange.etl.getSourceDatabase(),Database.generateModelFromCSV(fileName));
+		
+		etl.copyETLMappings(ObjectExchange.etl);
+		tableMappingPanel.setMapping(etl.getTableToTableMapping());	
+		ObjectExchange.etl = etl;
+		
+	}
+
 	private void doSetTargetCDM(CDMVersion cdmVersion) {
 		ETL etl = new ETL(ObjectExchange.etl.getSourceDatabase(),Database.generateCDMModel(cdmVersion));
 		

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -58,7 +58,7 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 	public final static String		ACTION_CMD_REMOVE_MAPPING			= "Remove Mappings";
 	public final static String		ACTION_CMD_SET_TARGET_V4			= "CDM v4";
 	public final static String		ACTION_CMD_SET_TARGET_V5			= "CDM v5";
-	public final static String		ACTION_CMD_SET_TARGET_CUSTOM		= "Load Target";
+	public final static String		ACTION_CMD_SET_TARGET_CUSTOM		= "Load Custom...";
 	
 	private final static FileFilter	FILE_FILTER_GZ					= new FileNameExtensionFilter("GZIP Files (*.gz)", "gz");
 	private final static FileFilter	FILE_FILTER_DOCX					= new FileNameExtensionFilter("Microsoft Word documents (*.docx)", "docx");
@@ -216,24 +216,23 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		removeMappings.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.CTRL_MASK));		
 		editMenu.add(removeMappings);
 		
-		JMenu setTarget = new JMenu("Set Target Database");
-				
-		JMenuItem loadTarget = new JMenuItem(ACTION_CMD_SET_TARGET_CUSTOM);
-		loadTarget.addActionListener(this);
-		loadTarget.setActionCommand(ACTION_CMD_SET_TARGET_CUSTOM);
-		setTarget.add(loadTarget);		
-		editMenu.add(setTarget);
-		
+		JMenu setTarget = new JMenu("Set Target Database");				
+	
 		JMenuItem targetCDMV4 = new JMenuItem(ACTION_CMD_SET_TARGET_V4);
 		targetCDMV4.addActionListener(this);
 		targetCDMV4.setActionCommand(ACTION_CMD_SET_TARGET_V4);
 		setTarget.add(targetCDMV4);		
-		editMenu.add(setTarget);
 		
 		JMenuItem targetCDMV5 = new JMenuItem(ACTION_CMD_SET_TARGET_V5);
 		targetCDMV5.addActionListener(this);
 		targetCDMV5.setActionCommand(ACTION_CMD_SET_TARGET_V5);
 		setTarget.add(targetCDMV5);		
+		
+		JMenuItem loadTarget = new JMenuItem(ACTION_CMD_SET_TARGET_CUSTOM);
+		loadTarget.addActionListener(this);
+		loadTarget.setActionCommand(ACTION_CMD_SET_TARGET_CUSTOM);
+		setTarget.add(loadTarget);		
+		
 		editMenu.add(setTarget);
 
 		// JMenu viewMenu = new JMenu("View");

--- a/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/src/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -335,9 +335,10 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 	
 	private void doSetTargetCDM(CDMVersion cdmVersion) {
 		ETL etl = new ETL(ObjectExchange.etl.getSourceDatabase(),Database.generateCDMModel(cdmVersion));
-	
+		
+		etl.copyETLMappings(ObjectExchange.etl);
+		tableMappingPanel.setMapping(etl.getTableToTableMapping());	
 		ObjectExchange.etl = etl;
-		tableMappingPanel.setMapping(ObjectExchange.etl.getTableToTableMapping());		
 	}
 
 	//Opens Filter dialog window

--- a/src/org/ohdsi/rabbitInAHat/dataModel/Database.java
+++ b/src/org/ohdsi/rabbitInAHat/dataModel/Database.java
@@ -17,6 +17,7 @@
  ******************************************************************************/
 package org.ohdsi.rabbitInAHat.dataModel;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,13 +62,21 @@ public class Database implements Serializable {
 	}
 
 	public static Database generateCDMModel(CDMVersion cdmVersion) {
+		String path = Database.class.getResource(cdmVersion.fileName).getFile();
+		return Database.generateModelFromCSV(path);
+	}
+	
+	public static Database generateModelFromCSV(String fileName) {
 		Database database = new Database();
 		
-		database.dbName = cdmVersion.dbName;
-		
+		String dbname = new File(fileName).getName();
+		database.dbName = dbname.substring(0,dbname.lastIndexOf("."));
+				
 		Map<String, Table> nameToTable = new HashMap<String, Table>();
-		for (Row row : new ReadCSVFileWithHeader(Database.class.getResourceAsStream(cdmVersion.fileName))) {
+		for (Row row : new ReadCSVFileWithHeader(fileName)) {
+			
 			Table table = nameToTable.get(row.get("TABLE_NAME").toLowerCase());
+			
 			if (table == null) {
 				table = new Table();
 				table.setDb(database);
@@ -81,7 +90,7 @@ public class Database implements Serializable {
 			field.setDescription(row.get("DESCRIPTION"));
 			table.getFields().add(field);
 		}
-		// database.defaultOrdering = new ArrayList<Table>(database.tables);
+
 		return database;
 	}
 

--- a/src/org/ohdsi/rabbitInAHat/dataModel/ETL.java
+++ b/src/org/ohdsi/rabbitInAHat/dataModel/ETL.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import org.ohdsi.rabbitInAHat.MappingComponent;
+
 import com.cedarsoftware.util.io.JsonReader;
 import com.cedarsoftware.util.io.JsonWriter;
 
@@ -46,13 +48,28 @@ public class ETL implements Serializable {
 	private transient String						filename					= null;
 	private static final long						serialVersionUID			= 8987388381751618498L;
 
-	public ETL(){
-		
+	public ETL(){		
 	}
+	
 	public ETL(Database sourceDB, Database targetDb){
 		this.setSourceDatabase(sourceDB);
 		this.setTargetDatabase(targetDb);
 	}
+	
+	public void copyETLMappings(ETL etl){
+		Mapping<Table> oldTableMapping = etl.getTableToTableMapping();
+		Mapping<Table> newTableMapping = this.getTableToTableMapping();
+		Mapping<Field> oldFieldMapping;
+		
+		for(Table sourceTable : sourceDb.getTables()){
+			for(Table targetTable : targetDb.getTables()){			
+				if( oldTableMapping.getSourceToTargetMapByName(sourceTable, targetTable) != null ){
+					newTableMapping.addSourceToTargetMap(sourceTable,targetTable);
+				}
+			}
+		}
+	}
+	
 	public void saveCurrentState() {
 
 	}

--- a/src/org/ohdsi/rabbitInAHat/dataModel/ItemToItemMap.java
+++ b/src/org/ohdsi/rabbitInAHat/dataModel/ItemToItemMap.java
@@ -57,7 +57,7 @@ public class ItemToItemMap implements Serializable {
 	
 	public boolean equals(Object other) {
 		if (other instanceof ItemToItemMap) {
-			return (((ItemToItemMap) other).sourceItem.equals(sourceItem) && ((ItemToItemMap) other).cdmItem.equals(cdmItem));
+			return (((ItemToItemMap) other).sourceItem.getName().equals(sourceItem.getName()) && ((ItemToItemMap) other).cdmItem.getName().equals(cdmItem.getName()));
 		} else
 			return false;
 	}

--- a/src/org/ohdsi/rabbitInAHat/dataModel/Mapping.java
+++ b/src/org/ohdsi/rabbitInAHat/dataModel/Mapping.java
@@ -36,6 +36,10 @@ public class Mapping <T extends MappableItem>{
 		sourceToCdmMaps.add(new ItemToItemMap(sourceItem, targetItem));
 	}
 	
+	public void addSourceToTargetMap(ItemToItemMap itemToItemMap) {
+		sourceToCdmMaps.add(itemToItemMap);
+	}
+	
 	public List<MappableItem> getSourceItems() {
 		List<MappableItem> list = new ArrayList<MappableItem>();
 		for (MappableItem item : sourceItems)
@@ -89,7 +93,8 @@ public class Mapping <T extends MappableItem>{
 	}
 	
 	public ItemToItemMap getSourceToTargetMapByName(MappableItem sourceItem, MappableItem targetItem) {
-		Iterator<ItemToItemMap> iterator = sourceToTargetMaps.iterator();
+		Iterator<ItemToItemMap> iterator = sourceToCdmMaps.iterator();
+
 		while (iterator.hasNext()) {
 			ItemToItemMap sourceToTargetMap = iterator.next();
 			if (sourceToTargetMap.getSourceItem().getName().equals(sourceItem.getName()) && sourceToTargetMap.getTargetItem().getName().equals(targetItem.getName()))

--- a/src/org/ohdsi/rabbitInAHat/dataModel/Mapping.java
+++ b/src/org/ohdsi/rabbitInAHat/dataModel/Mapping.java
@@ -87,4 +87,14 @@ public class Mapping <T extends MappableItem>{
 		}
 		return null;
 	}
+	
+	public ItemToItemMap getSourceToTargetMapByName(MappableItem sourceItem, MappableItem targetItem) {
+		Iterator<ItemToItemMap> iterator = sourceToTargetMaps.iterator();
+		while (iterator.hasNext()) {
+			ItemToItemMap sourceToTargetMap = iterator.next();
+			if (sourceToTargetMap.getSourceItem().getName().equals(sourceItem.getName()) && sourceToTargetMap.getTargetItem().getName().equals(targetItem.getName()))
+				return sourceToTargetMap;
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
Allows mappings between source and target to stay when swapping schema's by matching the names of the old tables/fields to the new tables/fields and keeping any connections whose names match.  

Also allows user to load a custom target schema as a csv file by going to Edit > Set Target Database > Load Custom... .  

The csv file must have the following columns:
- TABLE_NAME  = Name of the table (gets repeated for each COLUMN_NAME in a table)
- COLUMN_NAME = Name of column in the table
- IS_NULLABLE = YES/NO value for whether the field is nullable
- DATA_TYPE = Data type of the field
- DESCRIPTION = A description of the data that goes in the field

This closes #44 and #23.  