### PR TITLE
Don't allow dragging when filtering

### DIFF
--- a/src/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/src/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -526,7 +526,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			repaint();
 		} else {
 			for (LabeledRectangle item : getVisibleSourceComponents()) {
-				if (item.contains(event.getPoint())) {
+				if (item.contains(event.getPoint()) && !isBeingFiltered()) {
 					dragRectangle = item;
 					dragOffsetY = event.getY() - item.getY();
 					break;
@@ -534,7 +534,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			}
 
 			for (LabeledRectangle item : getVisibleTargetComponents()) {
-				if (item.contains(event.getPoint())) {
+				if (item.contains(event.getPoint()) && !isBeingFiltered()) {
 					dragRectangle = item;
 					dragOffsetY = event.getY() - item.getY();
 					break;
@@ -815,5 +815,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		}
 		
 		return resString;
+	}
+	
+	public boolean isBeingFiltered() {
+		return lastSourceFilter != "" || lastTargetFilter != ""; 
 	}
 }


### PR DESCRIPTION
Sidesteps an odd issue where once we filter the source or target, if we click on a source or target box, the box is considered "dragged" and we reorder all the items based on that drag, but not all items are visible and so the sort order of all the boxes becomes corrupted.

Our solution is to just not allow people to reorder (i.e. drag) boxes when the filter is active.