### PR TITLE
Pass arguments thru RiaH Launcher

### DIFF
--- a/src/org/ohdsi/utilities/RabbitInAHatLauncher.java
+++ b/src/org/ohdsi/utilities/RabbitInAHatLauncher.java
@@ -2,6 +2,9 @@ package org.ohdsi.utilities;
 
 import org.ohdsi.rabbitInAHat.RabbitInAHatMain;
 
+import java.util.Arrays;
+import java.util.ArrayList;
+
 /* Adapted from code found on:
  * http://silentdevelopment.blogspot.com/2010/03/how-to-set-or-increase-xmx-heap-memory.html
  */
@@ -18,7 +21,10 @@ public class RabbitInAHatLauncher {
 		} else {
 			System.out.println("Starting new VM");
 			String pathToJar = RabbitInAHatMain.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
-			ProcessBuilder pb = new ProcessBuilder("java", "-Xmx" + MIN_HEAP + "m", "-classpath", pathToJar, "org.ohdsi.rabbitInAHat.RabbitInAHatMain");
+			ArrayList<String> command = new ArrayList<String>();
+			command.addAll(Arrays.asList("java", "-Xmx" + MIN_HEAP + "m", "-classpath", pathToJar, "org.ohdsi.rabbitInAHat.RabbitInAHatMain"));
+			command.addAll(Arrays.asList(args));
+			ProcessBuilder pb = new ProcessBuilder(command);
 			pb.start();
 		}
 	}


### PR DESCRIPTION
Implementing #52 killed #51 because #52 didn't pass the command line arguments along when launching a new process