### PR TITLE
Updates layout of filter dialog for a more consistent look and feel

### DIFF
--- a/src/org/ohdsi/rabbitInAHat/FilterDialog.java
+++ b/src/org/ohdsi/rabbitInAHat/FilterDialog.java
@@ -1,16 +1,17 @@
 package org.ohdsi.rabbitInAHat;
 
+import java.awt.Container;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+
 import org.ohdsi.rabbitInAHat.ResizeListener;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
-import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SpringLayout;
 
@@ -29,19 +30,19 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 
 	SpringLayout layout = new SpringLayout();
 	
-	JPanel mainView = new JPanel(layout);
+	Container contentPane = this.getContentPane();
 	
 	public FilterDialog(Window parentWindow){
 		
 		super(parentWindow,"Filter",ModalityType.MODELESS);		
-						
+		this.setResizable(false);
 		this.setLocation(parentWindow.getX()+parentWindow.getWidth()/2, parentWindow.getY()+100);
-		this.setSize(700,120);
-		
-		sourceSearchField = new JTextField(40);
+
+		contentPane.setLayout(layout);
+		sourceSearchField = new JTextField(30);
 		sourceSearchField.setName("Source");
 		
-		targetSearchField = new JTextField(40);
+		targetSearchField = new JTextField(30);
 		targetSearchField.setName("Target");
 
 		
@@ -49,40 +50,46 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 		sourceSearchField.addKeyListener(new SearchListener() );
 		JLabel sourceLabel = new JLabel("Filter Source:",JLabel.TRAILING);
 		JButton sourceClearBtn = new JButton("Clear");
-		mainView.add(sourceLabel);
-		mainView.add(sourceSearchField);
+		contentPane.add(sourceLabel);
+		contentPane.add(sourceSearchField);
 		sourceClearBtn.addActionListener(this);
 		sourceClearBtn.setActionCommand("Clear Source");
-		mainView.add(sourceClearBtn);
+		contentPane.add(sourceClearBtn);
 		
 		targetSearchField.addKeyListener(new SearchListener() );
 		JLabel targetLabel = new JLabel("Filter Target:",JLabel.TRAILING);
 		JButton targetClearBtn = new JButton("Clear");
-		mainView.add(targetLabel);
-		mainView.add(targetSearchField);		
+		contentPane.add(targetLabel);
+		contentPane.add(targetSearchField);		
 		targetClearBtn.addActionListener(this);
 		targetClearBtn.setActionCommand("Clear Target");
-		mainView.add(targetClearBtn);
+		contentPane.add(targetClearBtn);
 		
-		layout.putConstraint(SpringLayout.WEST, sourceLabel, 10, SpringLayout.WEST, mainView);
-		layout.putConstraint(SpringLayout.NORTH, sourceLabel, 10, SpringLayout.NORTH, mainView);
+		layout.putConstraint(SpringLayout.WEST, sourceLabel, 5, SpringLayout.WEST, contentPane);
+		layout.putConstraint(SpringLayout.NORTH, sourceLabel, 5, SpringLayout.NORTH, contentPane);
 		
 		layout.putConstraint(SpringLayout.WEST, sourceSearchField, 5, SpringLayout.EAST, sourceLabel);
-		layout.putConstraint(SpringLayout.NORTH, sourceSearchField, 10, SpringLayout.NORTH, mainView);
+		layout.putConstraint(SpringLayout.NORTH, sourceSearchField, 5, SpringLayout.NORTH, contentPane);
 		
 		layout.putConstraint(SpringLayout.WEST, sourceClearBtn, 5, SpringLayout.EAST, sourceSearchField);
-		layout.putConstraint(SpringLayout.NORTH, sourceClearBtn, 10, SpringLayout.NORTH, mainView);
+		layout.putConstraint(SpringLayout.NORTH, sourceClearBtn, 5, SpringLayout.NORTH, contentPane);
 		
-		layout.putConstraint(SpringLayout.WEST, targetLabel, 10, SpringLayout.WEST, mainView);
+		layout.putConstraint(SpringLayout.WEST, targetLabel, 5, SpringLayout.WEST, contentPane);
 		layout.putConstraint(SpringLayout.NORTH, targetLabel, 10, SpringLayout.SOUTH, sourceLabel);
 		
 		layout.putConstraint(SpringLayout.WEST, targetSearchField, 0, SpringLayout.WEST, sourceSearchField);
 		layout.putConstraint(SpringLayout.NORTH, targetSearchField, 0, SpringLayout.NORTH, targetLabel);
 		
 		layout.putConstraint(SpringLayout.WEST, targetClearBtn, 5, SpringLayout.EAST, targetSearchField);
-		layout.putConstraint(SpringLayout.NORTH, targetClearBtn, 0, SpringLayout.NORTH, targetSearchField);
+		layout.putConstraint(SpringLayout.NORTH, targetClearBtn, 0, SpringLayout.NORTH, targetSearchField);		
+
 		
-		this.add(mainView);
+		layout.putConstraint(SpringLayout.SOUTH, contentPane, 5, SpringLayout.SOUTH, targetLabel);
+		layout.putConstraint(SpringLayout.NORTH, contentPane, 5, SpringLayout.NORTH, sourceLabel);
+		layout.putConstraint(SpringLayout.WEST, contentPane, 5, SpringLayout.WEST, sourceLabel);
+		layout.putConstraint(SpringLayout.EAST, contentPane, 5, SpringLayout.EAST, targetClearBtn);
+		
+		this.pack();
 	};
 	
 	public void setFilterPanel(MappingPanel aFilterPanel){

--- a/src/org/ohdsi/rabbitInAHat/FilterDialog.java
+++ b/src/org/ohdsi/rabbitInAHat/FilterDialog.java
@@ -4,6 +4,8 @@ import java.awt.Container;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
@@ -48,21 +50,25 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 		
 		// Add key listener to send search string as it's being typed
 		sourceSearchField.addKeyListener(new SearchListener() );
+		sourceSearchField.addFocusListener(new SearchFocusListener());		
 		JLabel sourceLabel = new JLabel("Filter Source:",JLabel.TRAILING);
 		JButton sourceClearBtn = new JButton("Clear");
 		contentPane.add(sourceLabel);
 		contentPane.add(sourceSearchField);
 		sourceClearBtn.addActionListener(this);
 		sourceClearBtn.setActionCommand("Clear Source");
+		sourceClearBtn.setFocusable(false);
 		contentPane.add(sourceClearBtn);
 		
 		targetSearchField.addKeyListener(new SearchListener() );
+		targetSearchField.addFocusListener(new SearchFocusListener());
 		JLabel targetLabel = new JLabel("Filter Target:",JLabel.TRAILING);
 		JButton targetClearBtn = new JButton("Clear");
 		contentPane.add(targetLabel);
 		contentPane.add(targetSearchField);		
 		targetClearBtn.addActionListener(this);
 		targetClearBtn.setActionCommand("Clear Target");
+		targetClearBtn.setFocusable(false);
 		contentPane.add(targetClearBtn);
 		
 		layout.putConstraint(SpringLayout.WEST, sourceLabel, 5, SpringLayout.WEST, contentPane);
@@ -179,6 +185,23 @@ public class FilterDialog extends JDialog implements ActionListener, ResizeListe
 				
 			}
 		
+	}
+	
+	public class SearchFocusListener implements FocusListener {
+
+		@Override
+		public void focusGained(FocusEvent e) {
+			// TODO Auto-generated method stub
+			JTextField jtf = (JTextField) e.getComponent();
+			jtf.selectAll();
+		}
+
+		@Override
+		public void focusLost(FocusEvent e) {
+			// TODO Auto-generated method stub
+
+		}
+
 	}
 	
 	


### PR DESCRIPTION
Gives a more unified look and feel for the filter dialog box:

- Turned off resizing
- Laid out elements in a more consistent way across platforms
- Removed the ability to tab to "Clear" buttons
- Added select all text in text field when it gains focus