### PR TITLE
Remove console.setDebugFile

### DIFF
--- a/src/org/ohdsi/whiteRabbit/WhiteRabbitMain.java
+++ b/src/org/ohdsi/whiteRabbit/WhiteRabbitMain.java
@@ -526,7 +526,6 @@ public class WhiteRabbitMain implements ActionListener {
 		consoleArea.setEditable(false);
 		Console console = new Console();
 		console.setTextArea(consoleArea);
-		console.setDebugFile("c:/temp/debug.txt");
 		System.setOut(new PrintStream(console));
 		System.setErr(new PrintStream(console));
 		JScrollPane consoleScrollPane = new JScrollPane(consoleArea);


### PR DESCRIPTION
#94 describes an error I encountered when WhiteRabbit was running a scan on some files.

WhiteRabbit attempted to set the debug file to C:\temp\debug.txt, a path that is invalid Mac OS X.

I'm under the impression this line isn't critical and can be safely removed to get scanning working again.

Closes #94