### PR TITLE
Fix RiaH box text duplication

### DIFF
--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/LabeledRectangle.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/LabeledRectangle.java
@@ -126,20 +126,34 @@ public class LabeledRectangle implements MappingComponent {
 				index = nextBreakPoint(item.outputName(), index + 1);
 			}
 			if (breakPoint == 0) {
-				breakPoint = (int) midPoint;
+				breakPoint = (int) midPoint + 1;
 			} else {
 				breakPoint++;
 			}
 			String line1 = item.outputName().substring(0, breakPoint);
 			String line2 = item.outputName().substring(breakPoint);
-			r = fm.getStringBounds(line1, g2d);
-			int textX = (this.getWidth() - (int) r.getWidth()) / 2;
-			int textY = (this.getHeight() / 2 - (int) r.getHeight()) / 2 + fm.getAscent();
-			g2d.drawString(line1, x + textX, y + textY);
-			r = fm.getStringBounds(line2, g2d);
-			textX = (this.getWidth() - (int) r.getWidth()) / 2;
-			textY = (int) Math.round(this.getHeight() * 1.5 - (int) r.getHeight()) / 2 + fm.getAscent();
-			g2d.drawString(line2, x + textX, y + textY);
+
+			Rectangle2D r1 = fm.getStringBounds(line1, g2d);
+			Rectangle2D r2 = fm.getStringBounds(line2, g2d);
+			if (r1.getWidth() >= width) {
+				line1 = item.outputName().substring(0, (int) midPoint);
+				line2 = item.outputName().substring((int) midPoint);
+				r1 = fm.getStringBounds(line1, g2d);
+				r2 = fm.getStringBounds(line2, g2d);
+			} else if (r2.getWidth() >= width) {
+				line1 = item.outputName().substring(0, (int) midPoint);
+				line2 = item.outputName().substring((int) midPoint);
+				r1 = fm.getStringBounds(line1, g2d);
+				r2 = fm.getStringBounds(line2, g2d);
+			}
+			// If both lines are too wide, then the text will still go out of bounds
+			int textX1 = (this.getWidth() - (int) r1.getWidth()) / 2;
+			int textY1 = (this.getHeight() / 2 - (int) r1.getHeight()) / 2 + fm.getAscent();
+			g2d.drawString(line1, x + textX1, y + textY1);
+
+			int textX2 = (this.getWidth() - (int) r2.getWidth()) / 2;
+			int textY2 = (int) Math.round(this.getHeight() * 1.5 - (int) r2.getHeight()) / 2 + fm.getAscent();
+			g2d.drawString(line2, x + textX2, y + textY2);
 		} else {
 			int textX = (this.getWidth() - (int) r.getWidth()) / 2;
 			int textY = (this.getHeight() - (int) r.getHeight()) / 2 + fm.getAscent();

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/LabeledRectangle.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/LabeledRectangle.java
@@ -126,22 +126,20 @@ public class LabeledRectangle implements MappingComponent {
 				index = nextBreakPoint(item.outputName(), index + 1);
 			}
 			if (breakPoint == 0) {
-				int textX = (this.getWidth() - (int) r.getWidth()) / 2;
-				int textY = (this.getHeight() - (int) r.getHeight()) / 2 + fm.getAscent();
-				g2d.drawString(item.outputName(), x + textX, y + textY);
+				breakPoint = (int) midPoint;
 			} else {
 				breakPoint++;
-				String line1 = item.outputName().substring(0, breakPoint);
-				String line2 = item.outputName().substring(breakPoint);
-				r = fm.getStringBounds(line1, g2d);
-				int textX = (this.getWidth() - (int) r.getWidth()) / 2;
-				int textY = (this.getHeight() / 2 - (int) r.getHeight()) / 2 + fm.getAscent();
-				g2d.drawString(line1, x + textX, y + textY);
-				r = fm.getStringBounds(line2, g2d);
-				textX = (this.getWidth() - (int) r.getWidth()) / 2;
-				textY = (int) Math.round(this.getHeight() * 1.5 - (int) r.getHeight()) / 2 + fm.getAscent();
-				g2d.drawString(line2, x + textX, y + textY);
 			}
+			String line1 = item.outputName().substring(0, breakPoint);
+			String line2 = item.outputName().substring(breakPoint);
+			r = fm.getStringBounds(line1, g2d);
+			int textX = (this.getWidth() - (int) r.getWidth()) / 2;
+			int textY = (this.getHeight() / 2 - (int) r.getHeight()) / 2 + fm.getAscent();
+			g2d.drawString(line1, x + textX, y + textY);
+			r = fm.getStringBounds(line2, g2d);
+			textX = (this.getWidth() - (int) r.getWidth()) / 2;
+			textY = (int) Math.round(this.getHeight() * 1.5 - (int) r.getHeight()) / 2 + fm.getAscent();
+			g2d.drawString(line2, x + textX, y + textY);
 		} else {
 			int textX = (this.getWidth() - (int) r.getWidth()) / 2;
 			int textY = (this.getHeight() - (int) r.getHeight()) / 2 + fm.getAscent();

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/LabeledRectangle.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/LabeledRectangle.java
@@ -129,18 +129,19 @@ public class LabeledRectangle implements MappingComponent {
 				int textX = (this.getWidth() - (int) r.getWidth()) / 2;
 				int textY = (this.getHeight() - (int) r.getHeight()) / 2 + fm.getAscent();
 				g2d.drawString(item.outputName(), x + textX, y + textY);
+			} else {
+				breakPoint++;
+				String line1 = item.outputName().substring(0, breakPoint);
+				String line2 = item.outputName().substring(breakPoint);
+				r = fm.getStringBounds(line1, g2d);
+				int textX = (this.getWidth() - (int) r.getWidth()) / 2;
+				int textY = (this.getHeight() / 2 - (int) r.getHeight()) / 2 + fm.getAscent();
+				g2d.drawString(line1, x + textX, y + textY);
+				r = fm.getStringBounds(line2, g2d);
+				textX = (this.getWidth() - (int) r.getWidth()) / 2;
+				textY = (int) Math.round(this.getHeight() * 1.5 - (int) r.getHeight()) / 2 + fm.getAscent();
+				g2d.drawString(line2, x + textX, y + textY);
 			}
-			breakPoint++;
-			String line1 = item.outputName().substring(0, breakPoint);
-			String line2 = item.outputName().substring(breakPoint);
-			r = fm.getStringBounds(line1, g2d);
-			int textX = (this.getWidth() - (int) r.getWidth()) / 2;
-			int textY = (this.getHeight() / 2 - (int) r.getHeight()) / 2 + fm.getAscent();
-			g2d.drawString(line1, x + textX, y + textY);
-			r = fm.getStringBounds(line2, g2d);
-			textX = (this.getWidth() - (int) r.getWidth()) / 2;
-			textY = (int) Math.round(this.getHeight() * 1.5 - (int) r.getHeight()) / 2 + fm.getAscent();
-			g2d.drawString(line2, x + textX, y + textY);
 		} else {
 			int textX = (this.getWidth() - (int) r.getWidth()) / 2;
 			int textY = (this.getHeight() - (int) r.getHeight()) / 2 + fm.getAscent();


### PR DESCRIPTION
Fixes #186, bug where text in boxes was duplicated in some cases.

Also, if characters are out of bounds, the renderer will always try to make a break at the midpoint of the text. This reduces the out of bound characters. See screenshot comparison below (left is before fix, right is after this fix).

![before_after_fix_name_break_issue](https://user-images.githubusercontent.com/17825660/65707890-b4369f80-e08d-11e9-882a-31e45d21435b.png)

Two caveats:
 * Very long names (>45 chars) will still go out of bounds if it does not fit on two lines at all.
 * Long names with a 'natural break' (space or underscore) at the midpoint of the text result in the same box name as without the natural break.
