### PR TITLE
Markup export enhancement

### DIFF
--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
@@ -47,11 +47,9 @@ public class ETLMarkupDocumentGenerator {
 	}
 
 	public static void main(String[] args) {
-		// TODO: revert
-		ETL etl = ETL.fromFile("/Volumes/GoogleDrive/My Drive/PRIAS/Workshop/RabbitInAHat_Prias_v1.json.gz", FileFormat.GzipJson);
+		ETL etl = ETL.fromFile("c:/temp/markdown/exampleEtl.json.gz", FileFormat.GzipJson);
 		ETLMarkupDocumentGenerator generator = new ETLMarkupDocumentGenerator(etl);
-		generator.generate("/Users/Maxim/Desktop/temp-markdown/index.md", DocumentType.MARKDOWN);
-
+		generator.generate("c:/temp/markdown/index.html", DocumentType.HTML);
 	}
 
 	ETLMarkupDocumentGenerator(ETL etl) {
@@ -140,22 +138,22 @@ public class ETLMarkupDocumentGenerator {
 					for (ItemToItemMap fieldToFieldMap : fieldtoFieldMapping.getSourceToTargetMaps()) {
 						if (fieldToFieldMap.getTargetItem() == targetField) {
 							if (source.length() != 0)
-								source.append("\n");
+								source.append("<br>");
 							source.append(fieldToFieldMap.getSourceItem().getName().trim());
 
 							if (logic.length() != 0)
-								logic.append("\n");
+								logic.append("<br>");
 							logic.append(fieldToFieldMap.getLogic().trim());
 
 							if (comment.length() != 0)
-								comment.append("\n");
+								comment.append("<br>");
 							comment.append(fieldToFieldMap.getComment().trim());
 						}
 					}
 					for (Field field : targetTable.getFields()) {
 						if (field.getName().equals(targetField.getName())) {
 							if (comment.length() != 0)
-								comment.append("\n");
+								comment.append("<br>");
 							comment.append(field.getComment().trim());
 						}
 					}

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
@@ -66,16 +66,20 @@ public class ETLMarkupDocumentGenerator {
 		}
 
 		addTableLevelSection();
+		document.close("index");
 
 		for (Table targetTable : etl.getTargetDatabase().getTables()) {
 			addTargetTableSection(targetTable);
+			document.close(targetTable.getName());
 		}
 
-		document.addHeader2("Appendix: source tables");
+
+		document.addHeader1("Appendix: source tables");
 
 		for (Table sourceTable : etl.getSourceDatabase().getTables()) {
 			addSourceTablesAppendix(sourceTable);
 		}
+		document.close("source_appendix");
 
 		document.close();
 	}
@@ -199,6 +203,8 @@ public class ETLMarkupDocumentGenerator {
 		void addTable(List<Row> rows);
 
 		void close();
+
+		void close(String targetFileName);
 	}
 
 	private static class MarkdownDocument implements MarkupDocument {
@@ -213,11 +219,11 @@ public class ETLMarkupDocumentGenerator {
 		 * @param fileName  Full path of the markdown document to create
 		 */
 		MarkdownDocument(String fileName) {
-			this.fileName = fileName;
+			this.fileName = new File(fileName).getName();
 			mainFolder = new File(fileName).getParent();
 			filesFolder = new File(fileName).getName().replaceAll("(\\.md)|(\\.MD)", "_files");
 		}
-		
+
 		@Override
 		public void addHeader1(String header) {
 			lines.add("# " + header);
@@ -262,10 +268,23 @@ public class ETLMarkupDocumentGenerator {
 
 		@Override
 		public void close() {
-			WriteTextFile out = new WriteTextFile(fileName);
-			for (String line : lines)
+			this.close(fileName);
+		}
+
+		@Override
+		public void close(String targetFileName) {
+			if (lines.size() == 0) {
+				return;
+			}
+
+			WriteTextFile out = new WriteTextFile(mainFolder + "/" + targetFileName + ".md");
+			for (String line : lines) {
 				out.writeln(line);
+			}
 			out.close();
+
+			// Reset
+			lines = new ArrayList<>();
 		}
 
 		@Override
@@ -306,11 +325,10 @@ public class ETLMarkupDocumentGenerator {
 		 * @param fileName   Full path of the HTML file to create.
 		 */
 		HtmlDocument(String fileName) {
-			this.fileName = fileName;
+			this.fileName = new File(fileName).getName();
 			mainFolder = new File(fileName).getParent();
 			filesFolder = new File(fileName).getName().replaceAll("(\\.html?)|(\\.HTML?)", "_files");
 		}
-		
 
 		@Override
 		public void addHeader1(String header) {
@@ -356,10 +374,23 @@ public class ETLMarkupDocumentGenerator {
 
 		@Override
 		public void close() {
-			WriteTextFile out = new WriteTextFile(fileName);
-			for (String line : lines)
+			this.close(fileName);
+		}
+
+		@Override
+		public void close(String targetFileName) {
+			if (lines.size() == 0) {
+				return;
+			}
+
+			WriteTextFile out = new WriteTextFile(mainFolder + "/" + targetFileName + ".html");
+			for (String line : lines) {
 				out.writeln(line);
+			}
 			out.close();
+
+			// Reset
+			lines = new ArrayList<>();
 		}
 
 		@Override

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/ETLMarkupDocumentGenerator.java
@@ -19,8 +19,11 @@ package org.ohdsi.rabbitInAHat;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +38,6 @@ import org.ohdsi.rabbitInAHat.dataModel.Mapping;
 import org.ohdsi.rabbitInAHat.dataModel.Table;
 import org.ohdsi.utilities.StringUtilities;
 import org.ohdsi.utilities.files.Row;
-import org.ohdsi.utilities.files.WriteTextFile;
 
 public class ETLMarkupDocumentGenerator {
 
@@ -277,11 +279,14 @@ public class ETLMarkupDocumentGenerator {
 		@Override
 		public void write(String targetName) {
 			File outFile = new File(mainFolder, targetName + ".md");
-			WriteTextFile out = new WriteTextFile(outFile.getAbsolutePath());
-			for (String line : lines) {
-				out.writeln(line);
+			try (BufferedWriter bw = Files.newBufferedWriter(outFile.toPath());
+				 PrintWriter out = new PrintWriter(bw)) {
+				for (String line : lines) {
+					out.println(line);
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
 			}
-			out.close();
 
 			// Reset
 			lines = new ArrayList<>();
@@ -376,11 +381,14 @@ public class ETLMarkupDocumentGenerator {
 		@Override
 		public void write(String targetName) {
 			File outFile = new File(mainFolder, targetName + ".html");
-			WriteTextFile out = new WriteTextFile(outFile.getAbsolutePath());
-			for (String line : lines) {
-				out.writeln(line);
+			try (BufferedWriter bw = Files.newBufferedWriter(outFile.toPath());
+				 PrintWriter out = new PrintWriter(bw)) {
+				for (String line : lines) {
+					out.println(line);
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
 			}
-			out.close();
 
 			// Reset
 			lines = new ArrayList<>();

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -481,10 +481,10 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 				doGenerateEtlWordDoc(chooseSavePath(FILE_FILTER_DOCX));
 				break;
 			case ACTION_GENERATE_ETL_HTML_DOCUMENT:
-				doGenerateEtlHtmlDoc(chooseSavePath(FILE_FILTER_HTML));
+				doGenerateEtlHtmlDoc(chooseSaveDirectory());
 				break;
 			case ACTION_GENERATE_ETL_MD_DOCUMENT:
-				doGenerateEtlMdDoc(chooseSavePath(FILE_FILTER_MD));
+				doGenerateEtlMdDoc(chooseSaveDirectory());
 				break;
 			case ACTION_GENERATE_TEST_FRAMEWORK:
 				doGenerateTestFramework(chooseSavePath(FILE_FILTER_R));
@@ -740,20 +740,20 @@ public class RabbitInAHatMain implements ResizeListener, ActionListener {
 		}
 	}
 
-	private void doGenerateEtlHtmlDoc(String filename) {
-		if (filename != null) {
+	private void doGenerateEtlHtmlDoc(String directoryName) {
+		if (directoryName != null) {
 			frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 			ETLMarkupDocumentGenerator generator = new ETLMarkupDocumentGenerator(ObjectExchange.etl);
-			generator.generate(filename, DocumentType.HTML);
+			generator.generate(directoryName, DocumentType.HTML);
 			frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
 		}
 	}
 
-	private void doGenerateEtlMdDoc(String filename) {
-		if (filename != null) {
+	private void doGenerateEtlMdDoc(String directoryName) {
+		if (directoryName != null) {
 			frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 			ETLMarkupDocumentGenerator generator = new ETLMarkupDocumentGenerator(ObjectExchange.etl);
-			generator.generate(filename, DocumentType.MARKDOWN);
+			generator.generate(directoryName, DocumentType.MARKDOWN);
 			frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
 		}
 	}


### PR DESCRIPTION
Several changes to the md and html export:
 * Include source appendix, with a list of source tables/fields and comments
 * Write the export to multiple files. One file per target table, plus the index and source appendix. The index contains links to the other files.
 * Line breaks in table cells if information from multiple mappings is merged.
 * Minor refactoring