### PR TITLE
Scan SAS files 

### DIFF
--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -198,5 +198,10 @@
             <artifactId>avro</artifactId>
             <version>1.8.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.epam</groupId>
+            <artifactId>parso</artifactId>
+            <version>2.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/DbSettings.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/DbSettings.java
@@ -26,7 +26,8 @@ import org.ohdsi.databases.DbType;
 public class DbSettings {
 	public static int	DATABASE	= 1;
 	public static int	CSVFILES	= 2;
-	
+	public static int	SASFILES	= 3;
+
 	public int			dataType;
 	public List<String>	tables		= new ArrayList<String>();
 	

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/WhiteRabbitMain.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/WhiteRabbitMain.java
@@ -271,9 +271,11 @@ public class WhiteRabbitMain implements ActionListener {
 		sourceType = new JComboBox<>(new String[] { "Delimited text files", "SAS7bdat", "MySQL", "Oracle", "SQL Server", "PostgreSQL", "MS Access", "PDW", "Redshift", "Teradata", "BigQuery" });
 		sourceType.setToolTipText("Select the type of source data available");
 		sourceType.addItemListener(itemEvent -> {
-			sourceIsFiles = itemEvent.getItem().toString().equals("Delimited text files");
-			sourceIsSas = itemEvent.getItem().toString().equals("SAS7bdat");
+			String selectedSourceType = itemEvent.getItem().toString();
+			sourceIsFiles = selectedSourceType.equals("Delimited text files");
+			sourceIsSas = selectedSourceType.equals("SAS7bdat");
 			boolean sourceIsDatabase = !(sourceIsFiles || sourceIsSas);
+
 			sourceServerField.setEnabled(sourceIsDatabase);
 			sourceUserField.setEnabled(sourceIsDatabase);
 			sourcePasswordField.setEnabled(sourceIsDatabase);
@@ -281,24 +283,24 @@ public class WhiteRabbitMain implements ActionListener {
 			sourceDelimiterField.setEnabled(sourceIsFiles);
 			addAllButton.setEnabled(sourceIsDatabase);
 
-			if (sourceIsDatabase && itemEvent.getItem().toString().equals("Oracle")) {
+			if (sourceIsDatabase && selectedSourceType.equals("Oracle")) {
 				sourceServerField.setToolTipText("For Oracle servers this field contains the SID, servicename, and optionally the port: '<host>/<sid>', '<host>:<port>/<sid>', '<host>/<service name>', or '<host>:<port>/<service name>'");
 				sourceUserField.setToolTipText("For Oracle servers this field contains the name of the user used to log in");
 				sourcePasswordField.setToolTipText("For Oracle servers this field contains the password corresponding to the user");
 				sourceDatabaseField.setToolTipText("For Oracle servers this field contains the schema (i.e. 'user' in Oracle terms) containing the source tables");
-			} else if (sourceIsDatabase && itemEvent.getItem().toString().equals("PostgreSQL")) {
+			} else if (sourceIsDatabase && selectedSourceType.equals("PostgreSQL")) {
 				sourceServerField.setToolTipText("For PostgreSQL servers this field contains the host name and database name (<host>/<database>)");
 				sourceUserField.setToolTipText("The user used to log in to the server");
 				sourcePasswordField.setToolTipText("The password used to log in to the server");
 				sourceDatabaseField.setToolTipText("For PostgreSQL servers this field contains the schema containing the source tables");
-			} else if (sourceIsDatabase && itemEvent.getItem().toString().equals("BigQuery")) {
+			} else if (sourceIsDatabase && selectedSourceType.equals("BigQuery")) {
 				sourceServerField.setToolTipText("GBQ SA & UA:  ProjectID");
 				sourceUserField.setToolTipText("GBQ SA only: OAuthServiceAccountEMAIL");
 				sourcePasswordField.setToolTipText("GBQ SA only: OAuthPvtKeyPath");
 				sourceDatabaseField.setToolTipText("GBQ SA & UA: Data Set within ProjectID");
 			} else if (sourceIsDatabase) {
 				sourceServerField.setToolTipText("This field contains the name or IP address of the database server");
-				if (itemEvent.getItem().toString().equals("SQL Server")) {
+				if (selectedSourceType.equals("SQL Server")) {
 					sourceUserField.setToolTipText("The user used to log in to the server. Optionally, the domain can be specified as <domain>/<user> (e.g. 'MyDomain/Joe')");
 				} else {
 					sourceUserField.setToolTipText("The user used to log in to the server");

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
@@ -390,7 +390,7 @@ public class SourceDataScan {
 						fieldInfos.get(i).processValue(row.get(i));
 				}
 			}
-			if (sampleSize != -1 && lineNr == sampleSize)
+			if (lineNr == sampleSize)
 				break;
 		}
 		for (FieldInfo fieldInfo : fieldInfos)
@@ -403,28 +403,24 @@ public class SourceDataScan {
 		StringUtilities.outputWithTime("Scanning table " + filename);
 		List<FieldInfo> fieldInfos = new ArrayList<>();
 
-		// TODO: try with resources and print warning on exception
-		FileInputStream inputStream;
-		try {
-			inputStream = new FileInputStream(new File(filename));
-
+		try(FileInputStream inputStream = new FileInputStream(new File(filename))) {
 			SasFileReader sasFileReader = new SasFileReaderImpl(inputStream);
 
-			// TODO: retrieve more information from the sasFileProperties, like data type and length.
+			// It is possible to retrieve more information from the sasFileProperties, like data type and length.
 			SasFileProperties sasFileProperties = sasFileReader.getSasFileProperties();
 			for (Column column : sasFileReader.getColumns()) {
 				fieldInfos.add(new FieldInfo(column.getName()));
 			}
 
-			for (int i = 0; i < sasFileProperties.getRowCount(); i++) {
+			for (int lineNr = 0; lineNr < sasFileProperties.getRowCount(); lineNr++) {
 				Object[] row = sasFileReader.readNext();
 
 				if (row.length == fieldInfos.size()) { // Else there appears to be a formatting error, so skip
-					for (int j = 0; j < row.length; j++) {
-						fieldInfos.get(j).processValue(row[j] == null ? "" : row[j].toString());
+					for (int i = 0; i < row.length; i++) {
+						fieldInfos.get(i).processValue(row[i] == null ? "" : row[i].toString());
 					}
 				}
-				if (sampleSize != -1 && i == sampleSize)
+				if (lineNr == sampleSize)
 					break;
 			}
 			inputStream.close();


### PR DESCRIPTION
Uses the Parso library (https://lifescience.opensource.epam.com/parso.html) to read sas7bdat files and write a scan report. Implementation is similar to how CSV files are scanned.

Note that this PR does not support writing fake data in the sas7bdat format. The Parso library does not seem to support writing to sas files and as it is a proprietary format, I think this might not be possible.

Also, as this implementation processes a sas file similar to csv; it scans values to derive data types. However, a sas file has associated properties like a database which we can use to read data type and length without reading the values.