### PR TITLE
Show stem table as intermediate

### DIFF
--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -65,12 +65,10 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	public static final int				MIN_SPACE_BETWEEN_COLUMNS	= 200;
 	public static final int				ARROW_START_WIDTH			= 50;
 	public static final int				BORDER_HEIGHT				= 25;
-	public static final int 			STEM_TABLE_MARGIN           = 0;
 
-	private int						sourceX						= 10;
-	private int						cdmX						= 200;
-	private int						sourceStemX					= 105;
-	private int						targetStemX					= 105;
+	private int						sourceX;
+	private int						cdmX;
+	private int						stemX;
 
 	private Mapping<?>				mapping;
 	private List<LabeledRectangle>	sourceComponents			= new ArrayList<LabeledRectangle>();
@@ -166,14 +164,14 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		for (MappableItem item : mapping.getSourceItems())
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
-					sourceComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
+					sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(255, 128, 0)));
 			}
 		for (MappableItem item : mapping.getTargetItems())
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
-					cdmComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
+					cdmComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					cdmComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(128, 128, 255)));
 			}
@@ -243,11 +241,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		for (LabeledRectangle component : components) {
 			// Exception for laying out the stem table
 			if (component.getItem().isStem() && component.getItem() instanceof Table) {
-				if (xpos == cdmX) { // is target item
-					component.setLocation(targetStemX, HEADER_TOP_MARGIN);
-				} else { // is source item
-					component.setLocation(sourceStemX, HEADER_TOP_MARGIN);
-				}
+				component.setLocation(stemX, HEADER_TOP_MARGIN);
 				continue;
 			}
 
@@ -283,9 +277,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	public void setSize(int width, int height) {
 		sourceX = MARGIN;
 		cdmX = width - MARGIN - ITEM_WIDTH;
-
-		targetStemX = (sourceX + cdmX + ITEM_WIDTH) / 2 - STEM_ITEM_WIDTH - STEM_TABLE_MARGIN;
-		sourceStemX = (sourceX + cdmX + ITEM_WIDTH) / 2 + STEM_TABLE_MARGIN;
+		stemX = (sourceX + cdmX) / 2;
 
 		layoutItems();
 		super.setSize(width, height);
@@ -396,9 +388,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		}
 
 		boolean clickInSource = event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH;
-		boolean clickInSourceStem = event.getX() > sourceStemX && event.getX() < sourceStemX + STEM_ITEM_WIDTH;
+		boolean clickInSourceStem = event.getX() > stemX && event.getX() < stemX + STEM_ITEM_WIDTH;
 		boolean clickInTarget = event.getX() > cdmX && event.getX() < cdmX + ITEM_WIDTH;
-		boolean clickInTargetStem = event.getX() > targetStemX && event.getX() < targetStemX + STEM_ITEM_WIDTH;
+		boolean clickInTargetStem = event.getX() > stemX && event.getX() < stemX + STEM_ITEM_WIDTH;
 		boolean clickInArrow = event.getX() > sourceX + ITEM_WIDTH && event.getX() < cdmX;
 
 		if (clickInSource || clickInSourceStem) {
@@ -616,7 +608,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			layoutItems();
 		} else if (dragArrow != null) { // dragging arrow to set source and target
 			boolean arrowInCdm = event.getX() > cdmX - ARROW_START_WIDTH && event.getX() < cdmX + ITEM_WIDTH;
-			boolean arrowInStem = event.getX() > targetStemX - ARROW_START_WIDTH && event.getX() < targetStemX + STEM_ITEM_WIDTH;
+			boolean arrowInStem = event.getX() > stemX - ARROW_START_WIDTH && event.getX() < stemX + STEM_ITEM_WIDTH;
 			if (arrowInCdm || arrowInStem) {
 				for (LabeledRectangle component : getVisibleRectangles(cdmComponents)) {
 					if (component.contains(event.getPoint(), ARROW_START_WIDTH, 0)) {

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -58,7 +58,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 
 	public static int				ITEM_HEIGHT					= 50;
 	public static int				ITEM_WIDTH					= 200;
-	public static int				STEM_ITEM_WIDTH				= 100;
+	public static int 				STEM_TABLE_ITEM_WIDTH 		= 80;
 	public static int				MARGIN						= 10;
 	public static int				HEADER_HEIGHT				= 25;
 	public static int				HEADER_TOP_MARGIN			= 0;
@@ -165,14 +165,14 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		for (MappableItem item : mapping.getSourceItems())
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
-					sourceComponents.add(new LabeledRectangle(0, 400, STEM_ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
+					sourceComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_TABLE_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(255, 128, 0)));
 			}
 		for (MappableItem item : mapping.getTargetItems())
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
-					cdmComponents.add(new LabeledRectangle(0, 400, STEM_ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
+					cdmComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_TABLE_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					cdmComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(128, 128, 255)));
 			}
@@ -235,23 +235,24 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		if (dragRectangle != null && dragRectangle.getX() == xpos)
 			avoidY = dragRectangle.getY();
 		int y = HEADER_HEIGHT + HEADER_TOP_MARGIN;
-		for (int i = 0; i < components.size(); i++) {
-			LabeledRectangle item = components.get(i);
+		for (LabeledRectangle component : components) {
 
-			if (item.getItem().isStem()) {
-				if (xpos == cdmX) {
-					item.setLocation(targetStemX, HEADER_HEIGHT + HEADER_TOP_MARGIN);
-				} else {
-					item.setLocation(sourceStemX, HEADER_HEIGHT + HEADER_TOP_MARGIN);
+			// Exception for laying out the stem table
+			if (component.getItem().isStem() && component.getItem() instanceof Table) {
+				if (xpos == cdmX) { // is target item
+					component.setLocation(targetStemX, HEADER_HEIGHT + HEADER_TOP_MARGIN);
+				} else { // is source item
+					component.setLocation(sourceStemX, HEADER_HEIGHT + HEADER_TOP_MARGIN);
 				}
 				continue;
 			}
 
+			// All other tables and fields
 			if (y > avoidY - ITEM_HEIGHT && y <= avoidY + MARGIN)
 				y += MARGIN + ITEM_HEIGHT;
 
-			if (dragRectangle == null || item != dragRectangle) {
-				item.setLocation(xpos, y);
+			if (dragRectangle == null || component != dragRectangle) {
+				component.setLocation(xpos, y);
 				y += MARGIN + ITEM_HEIGHT;
 			}
 		}
@@ -279,7 +280,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		sourceX = MARGIN;
 		cdmX = width - MARGIN - ITEM_WIDTH;
 		targetStemX = (sourceX + cdmX) / 2;
-		sourceStemX = (sourceX + cdmX) / 2 + STEM_ITEM_WIDTH;
+		sourceStemX = (sourceX + cdmX) / 2 + STEM_TABLE_ITEM_WIDTH;
 
 		layoutItems();
 		super.setSize(width, height);
@@ -388,11 +389,18 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				component.setSelected(false);
 			}
 		}
-		if (event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH) { // Source component
+
+		boolean clickInSource = event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH;
+		boolean clickInSourceStem = event.getX() > sourceStemX && event.getX() < sourceStemX + STEM_TABLE_ITEM_WIDTH;
+		boolean clickInTarget = event.getX() > cdmX && event.getX() < cdmX + ITEM_WIDTH;
+		boolean clickInTargetStem = event.getX() > targetStemX && event.getX() < targetStemX + STEM_TABLE_ITEM_WIDTH;
+		boolean clickInArrow = event.getX() > sourceX + ITEM_WIDTH && event.getX() < cdmX;
+
+		if (clickInSource || clickInSourceStem) {
 			LabeledRectangleClicked(event, getVisibleSourceComponents());
-		} else if (event.getX() > cdmX && event.getX() < cdmX + ITEM_WIDTH) { // target component
+		} else if (clickInTarget || clickInTargetStem) {
 			LabeledRectangleClicked(event, getVisibleTargetComponents());
-		} else if (event.getX() > sourceX + ITEM_WIDTH && event.getX() < cdmX) { // Arrows
+		} else if (clickInArrow) {
 			lastSelectedRectangle = null;
 			Arrow clickedArrow = null;
 			for (HighlightStatus status : HighlightStatus.values()) {
@@ -603,7 +611,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			layoutItems();
 		} else if (dragArrow != null) { // dragging arrow to set source and target
 			boolean arrowInCdm = event.getX() > cdmX - ARROW_START_WIDTH && event.getX() < cdmX + ITEM_WIDTH;
-			boolean arrowInStem = event.getX() > targetStemX - ARROW_START_WIDTH && event.getX() < targetStemX + STEM_ITEM_WIDTH;
+			boolean arrowInStem = event.getX() > targetStemX - ARROW_START_WIDTH && event.getX() < targetStemX + STEM_TABLE_ITEM_WIDTH;
 			if (arrowInCdm || arrowInStem) {
 				for (LabeledRectangle component : getVisibleRectangles(cdmComponents)) {
 					if (component.contains(event.getPoint(), ARROW_START_WIDTH, 0)) {

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -56,15 +56,16 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 
 	private static final long		serialVersionUID			= 4589294949568810155L;
 
-	public static int				ITEM_HEIGHT					= 50;
-	public static int				ITEM_WIDTH					= 200;
-	public static int 				STEM_TABLE_ITEM_WIDTH 		= 80;
-	public static int				MARGIN						= 10;
-	public static int				HEADER_HEIGHT				= 25;
-	public static int				HEADER_TOP_MARGIN			= 0;
-	public static int				MIN_SPACE_BETWEEN_COLUMNS	= 200;
-	public static int				ARROW_START_WIDTH			= 50;
-	public static int				BORDER_HEIGHT				= 25;
+	public static final int				ITEM_HEIGHT					= 50;
+	public static final int				ITEM_WIDTH					= 200;
+	public static final int 			STEM_ITEM_WIDTH 			= 80;
+	public static final int				MARGIN						= 10;
+	public static final int				HEADER_HEIGHT				= 25;
+	public static final int				HEADER_TOP_MARGIN			= 0;
+	public static final int				MIN_SPACE_BETWEEN_COLUMNS	= 200;
+	public static final int				ARROW_START_WIDTH			= 50;
+	public static final int				BORDER_HEIGHT				= 25;
+	public static final int 			STEM_TABLE_MARGIN           = 0;
 
 	private int						sourceX						= 10;
 	private int						cdmX						= 200;
@@ -165,14 +166,14 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		for (MappableItem item : mapping.getSourceItems())
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
-					sourceComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_TABLE_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
+					sourceComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(255, 128, 0)));
 			}
 		for (MappableItem item : mapping.getTargetItems())
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
-					cdmComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_TABLE_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
+					cdmComponents.add(new LabeledRectangle(0, 400, item instanceof Table ? STEM_ITEM_WIDTH : ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					cdmComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(128, 128, 255)));
 			}
@@ -235,14 +236,17 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		if (dragRectangle != null && dragRectangle.getX() == xpos)
 			avoidY = dragRectangle.getY();
 		int y = HEADER_HEIGHT + HEADER_TOP_MARGIN;
+		if (ObjectExchange.etl.hasStemTable()) {
+			// Move all non-stem items
+			y = HEADER_TOP_MARGIN + ITEM_HEIGHT;
+		}
 		for (LabeledRectangle component : components) {
-
 			// Exception for laying out the stem table
 			if (component.getItem().isStem() && component.getItem() instanceof Table) {
 				if (xpos == cdmX) { // is target item
-					component.setLocation(targetStemX, HEADER_HEIGHT + HEADER_TOP_MARGIN);
+					component.setLocation(targetStemX, HEADER_TOP_MARGIN);
 				} else { // is source item
-					component.setLocation(sourceStemX, HEADER_HEIGHT + HEADER_TOP_MARGIN);
+					component.setLocation(sourceStemX, HEADER_TOP_MARGIN);
 				}
 				continue;
 			}
@@ -279,8 +283,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 	public void setSize(int width, int height) {
 		sourceX = MARGIN;
 		cdmX = width - MARGIN - ITEM_WIDTH;
-		targetStemX = (sourceX + cdmX) / 2;
-		sourceStemX = (sourceX + cdmX) / 2 + STEM_TABLE_ITEM_WIDTH;
+
+		targetStemX = (sourceX + cdmX + ITEM_WIDTH) / 2 - STEM_ITEM_WIDTH - STEM_TABLE_MARGIN;
+		sourceStemX = (sourceX + cdmX + ITEM_WIDTH) / 2 + STEM_TABLE_MARGIN;
 
 		layoutItems();
 		super.setSize(width, height);
@@ -391,9 +396,9 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		}
 
 		boolean clickInSource = event.getX() > sourceX && event.getX() < sourceX + ITEM_WIDTH;
-		boolean clickInSourceStem = event.getX() > sourceStemX && event.getX() < sourceStemX + STEM_TABLE_ITEM_WIDTH;
+		boolean clickInSourceStem = event.getX() > sourceStemX && event.getX() < sourceStemX + STEM_ITEM_WIDTH;
 		boolean clickInTarget = event.getX() > cdmX && event.getX() < cdmX + ITEM_WIDTH;
-		boolean clickInTargetStem = event.getX() > targetStemX && event.getX() < targetStemX + STEM_TABLE_ITEM_WIDTH;
+		boolean clickInTargetStem = event.getX() > targetStemX && event.getX() < targetStemX + STEM_ITEM_WIDTH;
 		boolean clickInArrow = event.getX() > sourceX + ITEM_WIDTH && event.getX() < cdmX;
 
 		if (clickInSource || clickInSourceStem) {
@@ -611,7 +616,7 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 			layoutItems();
 		} else if (dragArrow != null) { // dragging arrow to set source and target
 			boolean arrowInCdm = event.getX() > cdmX - ARROW_START_WIDTH && event.getX() < cdmX + ITEM_WIDTH;
-			boolean arrowInStem = event.getX() > targetStemX - ARROW_START_WIDTH && event.getX() < targetStemX + STEM_TABLE_ITEM_WIDTH;
+			boolean arrowInStem = event.getX() > targetStemX - ARROW_START_WIDTH && event.getX() < targetStemX + STEM_ITEM_WIDTH;
 			if (arrowInCdm || arrowInStem) {
 				for (LabeledRectangle component : getVisibleRectangles(cdmComponents)) {
 					if (component.contains(event.getPoint(), ARROW_START_WIDTH, 0)) {

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
@@ -16,6 +16,8 @@ import org.ohdsi.utilities.collections.Pair;
 
 public class StemTableFactory {
 
+	private static final String STEM_TABLE_NAME = "STEM";
+
 	public static void addStemTable(ETL etl) {
 		Database sourceDatabase = etl.getSourceDatabase();
 		Database targetDatabase = etl.getTargetDatabase();
@@ -47,7 +49,7 @@ public class StemTableFactory {
 		try {
 			Table sourceStemTable = new Table();
 			sourceStemTable.setStem(true);
-			sourceStemTable.setName("STEM");
+			sourceStemTable.setName(STEM_TABLE_NAME);
 			for (CSVRecord row : CSVFormat.RFC4180.withHeader().parse(new InputStreamReader(tableStream))) {
 				Field field = new Field(row.get("COLUMN_NAME").toLowerCase(), sourceStemTable);
 				field.setNullable(row.get("IS_NULLABLE").equals("YES"));
@@ -56,7 +58,6 @@ public class StemTableFactory {
 				field.setStem(true);
 				sourceStemTable.getFields().add(field);
 			}
-			sourceStemTable.setDb(sourceDatabase);
 			sourceDatabase.getTables().add(sourceStemTable);
 			Table targetStemTable = new Table(sourceStemTable);
 			targetStemTable.setDb(targetDatabase);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
@@ -47,9 +47,8 @@ public class StemTableFactory {
 		try {
 			Table sourceStemTable = new Table();
 			sourceStemTable.setStem(true);
+			sourceStemTable.setName("STEM");
 			for (CSVRecord row : CSVFormat.RFC4180.withHeader().parse(new InputStreamReader(tableStream))) {
-				if (sourceStemTable.getName() == null)
-					sourceStemTable.setName(row.get("TABLE_NAME").toLowerCase());
 				Field field = new Field(row.get("COLUMN_NAME").toLowerCase(), sourceStemTable);
 				field.setNullable(row.get("IS_NULLABLE").equals("YES"));
 				field.setType(row.get("DATA_TYPE"));

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/dataModel/StemTableFactory.java
@@ -16,7 +16,7 @@ import org.ohdsi.utilities.collections.Pair;
 
 public class StemTableFactory {
 
-	private static final String STEM_TABLE_NAME = "STEM";
+	private static final String STEM_TABLE_NAME = "stem_table";
 
 	public static void addStemTable(ETL etl) {
 		Database sourceDatabase = etl.getSourceDatabase();


### PR DESCRIPTION
The stem table is an intermediate table, but RiaH showed it as separate source and targets.

This PR puts the stem table between source and CDM target. This is the same as the usage of the stem table during ETL implementation helps thinking about it.

Note that the source and target component are overlaid in the UI and might therefore produce unexpected behaviour.

![image](https://user-images.githubusercontent.com/17825660/76107648-6c6f5900-5fd9-11ea-8327-bb052ba828b3.png)
