### PR TITLE
Add concept_class_id in riah concept id hints 

### DIFF
--- a/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/ConceptsMap.java
+++ b/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/ConceptsMap.java
@@ -41,15 +41,28 @@ public class ConceptsMap {
     private void load(String filename) throws IOException{
         try (InputStream conceptStream = Database.class.getResourceAsStream(filename)) {
             for (CSVRecord conceptRow : CSVFormat.RFC4180.withHeader().parse(new InputStreamReader(conceptStream))) {
-                String tableName = conceptRow.get("omop_cdm_table");
-                String fieldName = conceptRow.get("omop_cdm_field");
+                String omopTableName = conceptRow.get("omop_cdm_table");
+                String omopFieldName = conceptRow.get("omop_cdm_field");
 
                 Concept concept = new Concept();
                 concept.setConceptId(conceptRow.get("concept_id"));
                 concept.setConceptName(conceptRow.get("concept_name"));
                 concept.setStandardConcept(conceptRow.get("standard_concept"));
 
-                this.put(tableName, fieldName, concept);
+                // Optional fields
+                if (conceptRow.isSet("domain_id")) {
+                    concept.setDomainId(conceptRow.get("domain_id"));
+                }
+
+                if (conceptRow.isSet("vocabulary_id")) {
+                    concept.setVocabularyId(conceptRow.get("vocabulary_id"));
+                }
+
+                if (conceptRow.isSet("concept_class_id")) {
+                    concept.setConceptClassId(conceptRow.get("concept_class_id"));
+                }
+
+                this.put(omopTableName, omopFieldName, concept);
             }
         } catch (IOException e) {
             throw new IOException("Could not load concept_id hints: " + e.getMessage());
@@ -71,6 +84,9 @@ public class ConceptsMap {
         private String conceptId;
         private String conceptName;
         private String standardConcept;
+        private String domainId;
+        private String vocabularyId;
+        private String conceptClassId;
 
         public String getConceptId() {
             return conceptId;
@@ -94,6 +110,30 @@ public class ConceptsMap {
 
         void setStandardConcept(String standardConcept) {
             this.standardConcept = standardConcept;
+        }
+
+        public String getDomainId() {
+            return domainId;
+        }
+
+        public void setDomainId(String domainId) {
+            this.domainId = domainId;
+        }
+
+        public String getVocabularyId() {
+            return vocabularyId;
+        }
+
+        public void setVocabularyId(String vocabularyId) {
+            this.vocabularyId = vocabularyId;
+        }
+
+        public String getConceptClassId() {
+            return conceptClassId;
+        }
+
+        public void setConceptClassId(String conceptClassId) {
+            this.conceptClassId = conceptClassId;
         }
 
         public String toString() {

--- a/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Database.java
+++ b/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Database.java
@@ -43,7 +43,7 @@ public class Database implements Serializable {
 	private List<Table>			tables				= new ArrayList<Table>();
 	private static final long	serialVersionUID	= -3912166654601191039L;
 	private String				dbName				= "";
-	private static String		CONCEPT_ID_HINTS_FILE_NAME = "CDMConceptIDHints_v5.0_MAR-18.csv";
+	private static String		CONCEPT_ID_HINTS_FILE_NAME = "CDMConceptIDHints_v5.0_02-OCT-19.csv";
 
 	public List<Table> getTables() {
 		return tables;

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
@@ -381,19 +381,15 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			table.setBorder(new MatteBorder(1, 0, 1, 0, Color.BLACK));
 			table.setCellSelectionEnabled(true);
 
-			// Make first column wider if source panel or second column if this is a target field panel
-			int wideColumnIndex = isTargetFieldPanel ? 1 : 0;
-			TableColumn column;
-			for (int i = 0; i < table.getColumnCount(); i++) {
-				column = table.getColumnModel().getColumn(i);
-				if (i == wideColumnIndex) {
-					column.setPreferredWidth(500);
-				} else {
-					column.setPreferredWidth(50);
-				}
+			if (isTargetFieldPanel) {
+				// Wide columns for concept name and class id
+				table.getColumnModel().getColumn(1).setPreferredWidth(100);
+				table.getColumnModel().getColumn(2).setPreferredWidth(100);
 			}
 
 			if (!isTargetFieldPanel) {
+				// Wide column for value name
+				table.getColumnModel().getColumn(0).setPreferredWidth(500);
 				// Right align the frequency and percentage
 				DefaultTableCellRenderer rightRenderer = new DefaultTableCellRenderer();
 				rightRenderer.setHorizontalAlignment(SwingConstants.RIGHT);
@@ -481,7 +477,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			nameLabel			= new JLabel("");
 			rowCountLabel		= new JLabel("");
 			description			= new DescriptionTextArea ("");
-			valueTable			= new SimpleTableModel("Concept ID", "Concept Name", "Standard?");
+			valueTable			= new SimpleTableModel("Concept ID", "Concept Name", "Class", "Standard?");
 			commentsArea		= new JTextArea();
 			isTargetFieldPanel  = true;
 			super.initialise();
@@ -492,7 +488,12 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			valueTable.clear();
 			if (field.getConceptIdHints() != null) {
 				for (ConceptsMap.Concept conceptIdHint : field.getConceptIdHints()) {
-					valueTable.add(conceptIdHint.getConceptId(), conceptIdHint.getConceptName(), conceptIdHint.getStandardConcept());
+					valueTable.add(
+							conceptIdHint.getConceptId(),
+							conceptIdHint.getConceptName(),
+							conceptIdHint.getConceptClassId(),
+							conceptIdHint.getStandardConcept()
+					);
 				}
 			}
 		}

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
@@ -383,7 +383,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 
 			if (isTargetFieldPanel) {
 				// Wide columns for concept name and class id
-				table.getColumnModel().getColumn(1).setPreferredWidth(100);
+				table.getColumnModel().getColumn(1).setPreferredWidth(300);
 				table.getColumnModel().getColumn(2).setPreferredWidth(100);
 			}
 

--- a/rabbitinahat/src/main/resources/org/ohdsi/rabbitInAHat/dataModel/CDMConceptIDHints_v5.0_02-OCT-19.csv
+++ b/rabbitinahat/src/main/resources/org/ohdsi/rabbitInAHat/dataModel/CDMConceptIDHints_v5.0_02-OCT-19.csv
@@ -1,0 +1,1755 @@
+omop_cdm_table,omop_cdm_field,concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,standard_concept
+condition_occurrence,condition_type_concept_id,45756852,Carrier claim detail - 10th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756853,Carrier claim detail - 11th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756854,Carrier claim detail - 12th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756855,Carrier claim detail - 13th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756843,Carrier claim detail - 1st position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756844,Carrier claim detail - 2nd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756845,Carrier claim detail - 3rd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756846,Carrier claim detail - 4th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756847,Carrier claim detail - 5th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756848,Carrier claim detail - 6th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756849,Carrier claim detail - 7th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756850,Carrier claim detail - 8th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756851,Carrier claim detail - 9th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756835,Carrier claim header - 1st position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756836,Carrier claim header - 2nd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756837,Carrier claim header - 3rd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756838,Carrier claim header - 4th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756839,Carrier claim header - 5th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756840,Carrier claim header - 6th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756841,Carrier claim header - 7th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45756842,Carrier claim header - 8th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000246,Condition era - 0 days persistence window,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000247,Condition era - 30 days persistence window,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,5086,Condition tested for by diagnostic procedure,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,42894222,EHR Chief Complaint,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45754805,EHR Episode Entry,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,32019,EHR billing diagnosis,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,32020,EHR encounter diagnosis,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000245,EHR problem list entry,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44786628,First Position Condition,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000193,Inpatient detail - 10th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000194,Inpatient detail - 11th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000195,Inpatient detail - 12th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000196,Inpatient detail - 13th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000197,Inpatient detail - 14th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000198,Inpatient detail - 15th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44818709,Inpatient detail - 16th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44818710,Inpatient detail - 17th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44818711,Inpatient detail - 18th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44818712,Inpatient detail - 19th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000184,Inpatient detail - 1st position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44818713,Inpatient detail - 20th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000185,Inpatient detail - 2nd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000186,Inpatient detail - 3rd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000187,Inpatient detail - 4th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000188,Inpatient detail - 5th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000189,Inpatient detail - 6th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000190,Inpatient detail - 7th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000191,Inpatient detail - 8th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000192,Inpatient detail - 9th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000183,Inpatient detail - primary,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000209,Inpatient header - 10th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000210,Inpatient header - 11th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000211,Inpatient header - 12th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000212,Inpatient header - 13th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000213,Inpatient header - 14th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000214,Inpatient header - 15th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000200,Inpatient header - 1st position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000201,Inpatient header - 2nd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000202,Inpatient header - 3rd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000203,Inpatient header - 4th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000204,Inpatient header - 5th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000205,Inpatient header - 6th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000206,Inpatient header - 7th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000207,Inpatient header - 8th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000208,Inpatient header - 9th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000199,Inpatient header - primary,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,32424,NLP derived,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,43542353,Observation recorded from EHR,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000224,Outpatient detail - 10th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000225,Outpatient detail - 11th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000226,Outpatient detail - 12th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000227,Outpatient detail - 13th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000228,Outpatient detail - 14th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000229,Outpatient detail - 15th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000215,Outpatient detail - 1st position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000216,Outpatient detail - 2nd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000217,Outpatient detail - 3rd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000218,Outpatient detail - 4th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000219,Outpatient detail - 5th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000220,Outpatient detail - 6th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000221,Outpatient detail - 7th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000222,Outpatient detail - 8th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000223,Outpatient detail - 9th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000239,Outpatient header - 10th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000240,Outpatient header - 11th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000241,Outpatient header - 12th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000242,Outpatient header - 13th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000243,Outpatient header - 14th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000244,Outpatient header - 15th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000230,Outpatient header - 1st position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000231,Outpatient header - 2nd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000232,Outpatient header - 3rd position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000233,Outpatient header - 4th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000234,Outpatient header - 5th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000235,Outpatient header - 6th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000236,Outpatient header - 7th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000237,Outpatient header - 8th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,38000238,Outpatient header - 9th position,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,45905770,Patient Self-Reported Condition,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44786627,Primary Condition,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,42898140,Referral record,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,44786629,Secondary Condition,Type Concept,Condition Type,Condition Type,S
+condition_occurrence,condition_type_concept_id,32535,Tumor Registry,Type Concept,Condition Type,Condition Type,S
+cost,cost_concept_id,32017,Accumulated Deductible,Cost,Cost,Summary,S
+cost,cost_concept_id,32448,Actual acquisition cost,Cost,Cost,Detail,S
+cost,cost_concept_id,32447,Actual acquisition cost,Cost,Cost,Summary,S
+cost,cost_concept_id,32000,Allowed,Cost,Cost,Detail,S
+cost,cost_concept_id,31978,Allowed,Cost,Cost,Summary,S
+cost,cost_concept_id,32001,Allowed (calculated),Cost,Cost,Detail,S
+cost,cost_concept_id,31979,Allowed (calculated),Cost,Cost,Summary,S
+cost,cost_concept_id,32006,Average Wholesale,Cost,Cost,Detail,S
+cost,cost_concept_id,31984,Average Wholesale,Cost,Cost,Summary,S
+cost,cost_concept_id,32009,Balance bill,Cost,Cost,Detail,S
+cost,cost_concept_id,31987,Balance bill,Cost,Cost,Summary,S
+cost,cost_concept_id,32015,Bundled payment,Cost,Cost,Detail,S
+cost,cost_concept_id,31993,Bundled payment,Cost,Cost,Summary,S
+cost,cost_concept_id,32011,Capitation,Cost,Cost,Detail,S
+cost,cost_concept_id,31989,Capitation,Cost,Cost,Summary,S
+cost,cost_concept_id,32014,Care Coordination Fee,Cost,Cost,Detail,S
+cost,cost_concept_id,31992,Care Coordination Fee,Cost,Cost,Summary,S
+cost,cost_concept_id,31995,Charged,Cost,Cost,Detail,S
+cost,cost_concept_id,31973,Charged,Cost,Cost,Summary,S
+cost,cost_concept_id,31997,Coinsurance,Cost,Cost,Detail,S
+cost,cost_concept_id,31975,Coinsurance,Cost,Cost,Summary,S
+cost,cost_concept_id,31996,Copayment,Cost,Cost,Detail,S
+cost,cost_concept_id,31974,Copayment,Cost,Cost,Summary,S
+cost,cost_concept_id,32007,Cost,Cost,Cost,Detail,S
+cost,cost_concept_id,31985,Cost,Cost,Cost,Summary,S
+cost,cost_concept_id,31998,Deductible,Cost,Cost,Detail,S
+cost,cost_concept_id,31976,Deductible,Cost,Cost,Summary,S
+cost,cost_concept_id,32004,Fee,Cost,Cost,Detail,S
+cost,cost_concept_id,31982,Fee,Cost,Cost,Summary,S
+cost,cost_concept_id,32010,Incentive,Cost,Cost,Detail,S
+cost,cost_concept_id,31988,Incentive,Cost,Cost,Summary,S
+cost,cost_concept_id,32012,Lifetime limit,Cost,Cost,Detail,S
+cost,cost_concept_id,31990,Lifetime limit,Cost,Cost,Summary,S
+cost,cost_concept_id,32013,Net costs,Cost,Cost,Detail,S
+cost,cost_concept_id,31991,Net costs,Cost,Cost,Summary,S
+cost,cost_concept_id,32003,Out of pocket,Cost,Cost,Detail,S
+cost,cost_concept_id,31981,Out of pocket,Cost,Cost,Summary,S
+cost,cost_concept_id,32002,Paid,Cost,Cost,Detail,S
+cost,cost_concept_id,31980,Paid,Cost,Cost,Summary,S
+cost,cost_concept_id,32421,Patient liability,Cost,Cost,Detail,S
+cost,cost_concept_id,32420,Patient liability,Cost,Cost,Summary,S
+cost,cost_concept_id,32005,Pharmacy ingredient,Cost,Cost,Detail,S
+cost,cost_concept_id,31983,Pharmacy ingredient,Cost,Cost,Summary,S
+cost,cost_concept_id,31972,"Premium, employer contribution",Cost,Cost,Summary,S
+cost,cost_concept_id,31971,"Premium, member contribution",Cost,Cost,Summary,S
+cost,cost_concept_id,32016,Rebate payment,Cost,Cost,Detail,S
+cost,cost_concept_id,31994,Rebate payment,Cost,Cost,Summary,S
+cost,cost_concept_id,31999,Recovered,Cost,Cost,Detail,S
+cost,cost_concept_id,31977,Recovered,Cost,Cost,Summary,S
+cost,cost_concept_id,32008,"Usual, customary and reasonable",Cost,Cost,Detail,S
+cost,cost_concept_id,31986,"Usual, customary and reasonable",Cost,Cost,Summary,S
+cost,cost_type_concept_id,31970,Payer system (Paid premium),Type Concept,Cost Type,Cost Type,S
+cost,cost_type_concept_id,31968,Payer system (Primary payer),Type Concept,Cost Type,Cost Type,S
+cost,cost_type_concept_id,31969,Payer system (Secondary payer),Type Concept,Cost Type,Cost Type,S
+cost,cost_type_concept_id,32504,Person (self) reported,Type Concept,Cost Type,Cost Type,S
+cost,cost_type_concept_id,32505,Provider System,Type Concept,Cost Type,Cost Type,S
+cost,cost_type_concept_id,5032,"Amount charged to the patient or the payer by the provider, list price",Type Concept,Cost Type,Cost Type,
+cost,cost_type_concept_id,5031,Amount paid by the patient or reimbursed by the payer,Type Concept,Cost Type,Cost Type,
+cost,cost_type_concept_id,5033,Cost incurred by the provider,Type Concept,Cost Type,Cost Type,
+death,death_type_concept_id,38003617,Death Certificate contributory cause,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32512,Death Certificate contributory cause,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32496,Death Certificate contributory cause,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003570,Death Certificate immediate cause,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32511,Death Certificate immediate cause,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32495,Death Certificate immediate cause,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003618,Death Certificate underlying cause,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32513,Death Certificate underlying cause,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32497,Death Certificate underlying cause,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,255,EHR Record contributory cause of death,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32516,EHR Record contributory cause of death,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32502,EHR Record contributory cause of death,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,254,EHR Record immediate cause of death,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32515,EHR Record immediate cause of death,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32501,EHR Record immediate cause of death,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,256,EHR Record underlying cause of death,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32517,EHR Record underlying cause of death,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32503,EHR Record underlying cause of death,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,44818516,"EHR discharge status ""Expired""",Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32514,"EHR discharge status ""Expired""",Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32498,"EHR discharge status ""Expired""",Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003569,"EHR record patient status ""Deceased""",Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32510,"EHR record patient status ""Deceased""",Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32494,"EHR record patient status ""Deceased""",Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003568,Medical claim DRG code indicating death,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32509,Medical claim DRG code indicating death,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32493,Medical claim DRG code indicating death,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003567,Medical claim diagnostic code indicating death,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32508,Medical claim diagnostic code indicating death,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32492,Medical claim diagnostic code indicating death,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003566,"Medical claim discharge status ""Died""",Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32507,"Medical claim discharge status ""Died""",Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32491,"Medical claim discharge status ""Died""",Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,242,Other government reported or identified death,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32518,Other government reported or identified death,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32499,Other government reported or identified death,Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,38003565,"Payer enrollment status ""Deceased""",Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32506,"Payer enrollment status ""Deceased""",Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32490,"Payer enrollment status ""Deceased""",Type Concept,Observation Type,Death Type,S
+death,death_type_concept_id,261,US Social Security Death Master File record,Type Concept,Condition Type,Death Type,S
+death,death_type_concept_id,32519,US Social Security Death Master File record,Type Concept,Death Type,Death Type,S
+death,death_type_concept_id,32500,US Social Security Death Master File record,Type Concept,Observation Type,Death Type,S
+device_exposure,device_type_concept_id,44818707,EHR Detail,Type Concept,Device Type,Device Type,S
+device_exposure,device_type_concept_id,32465,Inferred from claim,Type Concept,Device Type,Device Type,S
+device_exposure,device_type_concept_id,44818705,Inferred from procedure claim,Type Concept,Device Type,Device Type,S
+device_exposure,device_type_concept_id,44818706,Patient reported device,Type Concept,Device Type,Device Type,S
+drug_exposure,drug_type_concept_id,581452,Dispensed in Outpatient office,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000181,Drug era - 0 days persistence window,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000182,Drug era - 30 days persistence window,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000180,Inpatient administration,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000178,Medication list entry,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,32426,NLP derived,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,44787730,Patient Self-Reported Medication,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000179,Physician administered drug (identified as procedure),Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,43542358,Physician administered drug (identified from EHR observation),Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,581373,Physician administered drug (identified from EHR order),Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,43542356,Physician administered drug (identified from EHR problem list),Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,43542357,Physician administered drug (identified from referral record),Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000175,Prescription dispensed in pharmacy,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000176,Prescription dispensed through mail order,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,38000177,Prescription written,Type Concept,Drug Type,Drug Type,S
+drug_exposure,drug_type_concept_id,44777970,Randomized Drug,Type Concept,Drug Type,Drug Type,S
+drug_exposure,route_concept_id,44783786,Arteriovenous fistula route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,762840,Arteriovenous graft route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4023156,Auricular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4222254,Body cavity use,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4181897,Buccal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616201,Cardiovascular route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4220455,Caudal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616191,Central nervous system route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4168047,Colostomy route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40486444,Conjunctival route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40490507,Cutaneous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4163765,Dental,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40487501,Digestive tract route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616199,Ear and nose route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186831,Endocervical,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4157756,Endosinusial,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186832,Endotracheopulmonary,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4167540,Enteral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4225555,Epidural,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956880,Epilesional,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35608078,Epilesional route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4172191,Esophagostomy route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186833,Extraamniotic,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35624178,Extracorporeal hemodialysis route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,37018288,Extracorporeal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4304277,Fistula route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4168665,Gastro-intestinal stoma route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186834,Gastroenteral,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4132254,Gastrostomy route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616193,Genito-urinary route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616189,Genito-urinary stoma route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4156704,Gingival,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35627166,Haemodiafiltration,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,44801748,Haemodiafiltration route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956871,Haemodialysis,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956877,Haemofiltration,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4305679,Ileostomy route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,37397638,Infiltration route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956874,Inhalation,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4327128,Interstitial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,37103746,Intestinal use,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4304882,Intraabdominal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4163767,Intraamniotic,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4240824,Intraarterial,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4006860,Intraarticular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4223965,Intrabiliary route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303263,Intrabronchial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4163768,Intrabursal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303409,Intracameral,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4156705,Intracardiac,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303676,Intracartilaginous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35615950,Intracavernosal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4157757,Intracavernous,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40488317,Intracerebral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616203,Intracerebral ventricle route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4224886,Intracerebroventricular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956872,Intracervical,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4305993,Intracisternal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40489990,Intracolonic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4305690,Intracorneal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303667,Intracoronal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186836,Intracoronary,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492302,Intracorpus cavernosum route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171079,Intracranial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4156706,Intradermal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4163769,Intradiscal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4170083,Intraductal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4302354,Intraduodenal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492288,Intradural route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40487473,Intraepicardial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40487983,Intraepidermal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492284,Intraesophageal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492301,Intragastric route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492286,Intragingival route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40493258,Intrahepatic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40490837,Intraileal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40489989,Intrajejunal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4157758,Intralesional,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40493227,Intralingual route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4292410,Intraluminal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4157759,Intralymphatic,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40491321,Intramammary route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4246511,Intramedullary route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492300,Intrameningeal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,46272926,Intramural route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4302612,Intramuscular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4168038,Intramyometrial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,46272911,Intraneural route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4157760,Intraocular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4213522,Intraosseous,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4306657,Intraovarian route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492305,Intrapericardial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4243022,Intraperitoneal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4156707,Intrapleural,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171725,Intraprostatic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4169270,Intrapulmonary route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4169440,Intrasinal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4302788,Intraspinal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186837,Intrasternal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4302352,Intrasynovial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303939,Intratendinous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171067,Intratesticular route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4217202,Intrathecal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4167393,Intrathoracic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4229543,Intratracheal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40491322,Intratumoral,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4168656,Intratympanic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4269621,Intrauterine,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40492287,Intravascular route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171047,Intravenous,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4170113,Intravenous central route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171884,Intravenous peripheral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4222259,Intraventricular cardiac,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186838,Intravesical,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4302785,Intravitreal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956881,Iontophoresis,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4133177,Jejunostomy route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4170440,Laryngeal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35631981,Line lock,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40490898,Lower respiratory tract route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171243,Mucous fistula route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616198,Musculoskeletal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4262914,Nasal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4172316,Nasoduodenal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4132711,Nasogastric route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4305834,Nasojejunal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4184451,Ocular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4132161,Oral,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303795,Orogastric route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4186839,Oromucosal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303277,Oropharyngeal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303515,Paracervical route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4170267,Paravertebral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35627167,Percutaneous,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4177987,Percutaneous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4156708,Periarticular,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4304274,Peribulbar route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616224,Pericardial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40490896,Peridural route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4157761,Perineural,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40490866,Periodontal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35611042,Periosseous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4171893,Periosteal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616192,Peripheral nervous system route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4305564,Peritendinous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303646,Periurethral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4290759,Rectal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956879,Regional perfusion,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40486069,Respiratory tract route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616184,Respiratory-thoracic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4303673,Retrobulbar route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956875,Route of administration not applicable,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4106215,Route of administration value,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616200,Skin route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4163770,Subconjunctival,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4142048,Subcutaneous,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35608653,Subdermal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4306649,Subgingival route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,46270168,Sublesional route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4292110,Sublingual,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956878,Submucosal rectal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4169634,Submucosal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4166865,Suborbital route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,36703536,Subretinal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4302493,Subtendinous route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4170771,Surgical cavity route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4304412,Surgical drain route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4263689,Topical route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4304730,Transcervical route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4262099,Transdermal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40487850,Transendocardial route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35611043,Translingual route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4232601,Transmucosal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40487858,Transplacental route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40491832,Transtracheal route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,40491830,Transtympanic route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4305382,Transurethral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4169472,Tumor cavity route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4304571,Ureteral route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4233974,Urethral,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4170435,Urostomy route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,4057765,Vaginal,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,35616190,Wound route,Route,SNOMED,Qualifier Value,S
+drug_exposure,route_concept_id,45956883,Body cavity use,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,45956882,Epidural,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,4228125,Haemodialysis,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,4011083,Inhalation,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,45956885,Intracerebroventricular,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,4186835,Intracervical,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,45956886,Intraepidermal,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,45956884,Intraventricular cardiac,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,4302956,Iontophoresis,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,45956876,Obsolete-Intraventricular,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,45956873,Obsolete-Oromucosal other,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,4227373,Obsolete-Oromucosal other,Route,SNOMED,Qualifier Value,
+drug_exposure,route_concept_id,40549429,Ocular,Route,SNOMED,Qualifier Value,
+episode,episode_type_concept_id,32545,Episode algorithmically derived from EHR,Type Concept,Episode Type,Episode Type,S
+episode,episode_type_concept_id,32548,Episode algorithmically derived from claim,Type Concept,Episode Type,Episode Type,S
+episode,episode_type_concept_id,32544,Episode defined in EHR,Type Concept,Episode Type,Episode Type,S
+episode,episode_type_concept_id,32547,Episode derived from claim,Type Concept,Episode Type,Episode Type,S
+episode,episode_type_concept_id,32546,Episode derived from registry,Type Concept,Episode Type,Episode Type,S
+measurement,measurement_type_concept_id,32489,Accelerated lab result,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,45754907,Derived value,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,44818701,From physical examination,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,32466,Inferred from claim,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,44818702,Lab result,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,32423,NLP derived,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,44818703,Pathology finding,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,44818704,Patient reported value,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,5001,Test ordered through EHR,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,32534,Tumor Registry,Type Concept,Meas Type,Meas Type,S
+measurement,measurement_type_concept_id,32488,Urgent lab result,Type Concept,Meas Type,Meas Type,S
+measurement,operator_concept_id,4171756,<,Meas Value Operator,SNOMED,Qualifier Value,S
+measurement,operator_concept_id,4171754,<=,Meas Value Operator,SNOMED,Qualifier Value,S
+measurement,operator_concept_id,4172703,=,Meas Value Operator,SNOMED,Qualifier Value,S
+measurement,operator_concept_id,4172704,>,Meas Value Operator,SNOMED,Qualifier Value,S
+measurement,operator_concept_id,4171755,>=,Meas Value Operator,SNOMED,Qualifier Value,S
+note,note_type_concept_id,44814638,Admission note,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814643,Ancillary report,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814637,Discharge summary,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814646,Emergency department note,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814639,Inpatient note,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814645,Note,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814644,Nursing report,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814640,Outpatient note,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814642,Pathology report,Type Concept,Note Type,Note Type,S
+note,note_type_concept_id,44814641,Radiology report,Type Concept,Note Type,Note Type,S
+observation,observation_type_concept_id,38000282,Chief complaint,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,44786633,HRA Observation Numeric Result,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,44786634,HRA Observation Text,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,32467,Inferred from claim,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,38000279,Lab observation concept code result,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,38000277,Lab observation numeric result,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,38000278,Lab observation text,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,32445,NLP derived,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,45905771,Observation Recorded from a Survey,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,581413,Observation from Measurement,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,38000280,Observation recorded from EHR,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,38000281,Observation recorded from EHR with text result,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,44814721,Patient reported,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,38000276,Problem list from EHR,Type Concept,Observation Type,Observation Type,S
+observation,observation_type_concept_id,43542355,Referral Record,Type Concept,Observation Type,Observation Type,S
+observation_period,period_type_concept_id,44814724,Period covering healthcare encounters,Type Concept,Obs Period Type,Obs Period Type,S
+observation_period,period_type_concept_id,44814725,Period inferred by algorithm,Type Concept,Obs Period Type,Obs Period Type,S
+observation_period,period_type_concept_id,45890994,Period of complete data capture based on geographic isolation,Type Concept,Obs Period Type,Obs Period Type,S
+observation_period,period_type_concept_id,44814722,Period while enrolled in insurance,Type Concept,Obs Period Type,Obs Period Type,S
+observation_period,period_type_concept_id,44814723,Period while enrolled in study,Type Concept,Obs Period Type,Obs Period Type,S
+observation_period,period_type_concept_id,45747656,Pre-qualification time period,Type Concept,Obs Period Type,Obs Period Type,S
+payer_plan_period,plan_concept_id,268,"Broad Benefit (Medical, Drug, Dental, Vision) plan",Plan,Plan,Benefit,S
+payer_plan_period,plan_concept_id,263,Bronze Health Plan with 60% actuarial plan value,Plan,Plan,Metal level,S
+payer_plan_period,plan_concept_id,267,Catastrophic Health Plan with <60% actuarial plan value,Plan,Plan,Metal level,S
+payer_plan_period,plan_concept_id,271,Dental only plan,Plan,Plan,Benefit,S
+payer_plan_period,plan_concept_id,273,Drug only plan,Plan,Plan,Benefit,S
+payer_plan_period,plan_concept_id,265,Gold Health Plan with 80% actuarial plan value,Plan,Plan,Metal level,S
+payer_plan_period,plan_concept_id,270,Medical only plan,Plan,Plan,Benefit,S
+payer_plan_period,plan_concept_id,269,Minimal Benefit (Medical and Drug) plan,Plan,Plan,Benefit,S
+payer_plan_period,plan_concept_id,266,Platinum Health Plan with 90% actuarial plan value,Plan,Plan,Metal level,S
+payer_plan_period,plan_concept_id,264,Silver Health Plan with 70% actuarial plan value,Plan,Plan,Metal level,S
+payer_plan_period,plan_concept_id,272,Vision only plan,Plan,Plan,Benefit,S
+person,ethnicity_concept_id,38003563,Hispanic or Latino,Ethnicity,Ethnicity,Ethnicity,S
+person,ethnicity_concept_id,38003564,Not Hispanic or Latino,Ethnicity,Ethnicity,Ethnicity,S
+person,gender_concept_id,8532,FEMALE,Gender,Gender,Gender,S
+person,gender_concept_id,8507,MALE,Gender,Gender,Gender,S
+person,gender_concept_id,8570,AMBIGUOUS,Gender,Gender,Gender,
+person,gender_concept_id,45766035,Feminine gender,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,4268709,Gender finding,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,4214687,Gender unknown,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,45518388,Gender unknown,Gender,Read,Read,
+person,gender_concept_id,4215271,Gender unspecified,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,45454912,Gender unspecified,Gender,Read,Read,
+person,gender_concept_id,45438358,Male,Gender,Read,Read,
+person,gender_concept_id,45766034,Masculine gender,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,36675593,Non-binary gender,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,42689678,Non-binary gender,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,8521,OTHER,Gender,Gender,Gender,
+person,gender_concept_id,4234363,Surgically transgendered transsexual,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,4231242,"Surgically transgendered transsexual, female-to-male",Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,4251434,"Surgically transgendered transsexual, male-to-female",Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,36712829,Transgender identity,Gender,SNOMED,Clinical Finding,
+person,gender_concept_id,8551,UNKNOWN,Gender,Gender,Gender,
+person,race_concept_id,38003600,African,Race,Race,Race,S
+person,race_concept_id,38003599,African American,Race,Race,Race,S
+person,race_concept_id,38003573,Alaska Native,Race,Race,Race,S
+person,race_concept_id,38003572,American Indian,Race,Race,Race,S
+person,race_concept_id,8657,American Indian or Alaska Native,Race,Race,Race,S
+person,race_concept_id,38003616,Arab,Race,Race,Race,S
+person,race_concept_id,8515,Asian,Race,Race,Race,S
+person,race_concept_id,38003574,Asian Indian,Race,Race,Race,S
+person,race_concept_id,38003601,Bahamian,Race,Race,Race,S
+person,race_concept_id,38003575,Bangladeshi,Race,Race,Race,S
+person,race_concept_id,38003602,Barbadian,Race,Race,Race,S
+person,race_concept_id,38003576,Bhutanese,Race,Race,Race,S
+person,race_concept_id,38003598,Black,Race,Race,Race,S
+person,race_concept_id,8516,Black or African American,Race,Race,Race,S
+person,race_concept_id,38003577,Burmese,Race,Race,Race,S
+person,race_concept_id,38003578,Cambodian,Race,Race,Race,S
+person,race_concept_id,38003579,Chinese,Race,Race,Race,S
+person,race_concept_id,38003604,Dominica Islander,Race,Race,Race,S
+person,race_concept_id,38003603,Dominican,Race,Race,Race,S
+person,race_concept_id,38003614,European,Race,Race,Race,S
+person,race_concept_id,38003581,Filipino,Race,Race,Race,S
+person,race_concept_id,38003605,Haitian,Race,Race,Race,S
+person,race_concept_id,38003582,Hmong,Race,Race,Race,S
+person,race_concept_id,38003583,Indonesian,Race,Race,Race,S
+person,race_concept_id,38003593,Iwo Jiman,Race,Race,Race,S
+person,race_concept_id,38003606,Jamaican,Race,Race,Race,S
+person,race_concept_id,38003584,Japanese,Race,Race,Race,S
+person,race_concept_id,38003585,Korean,Race,Race,Race,S
+person,race_concept_id,38003586,Laotian,Race,Race,Race,S
+person,race_concept_id,38003597,Madagascar,Race,Race,Race,S
+person,race_concept_id,38003587,Malaysian,Race,Race,Race,S
+person,race_concept_id,38003594,Maldivian,Race,Race,Race,S
+person,race_concept_id,38003612,Melanesian,Race,Race,Race,S
+person,race_concept_id,38003611,Micronesian,Race,Race,Race,S
+person,race_concept_id,38003615,Middle Eastern or North African,Race,Race,Race,S
+person,race_concept_id,8557,Native Hawaiian or Other Pacific Islander,Race,Race,Race,S
+person,race_concept_id,38003595,Nepalese,Race,Race,Race,S
+person,race_concept_id,38003588,Okinawan,Race,Race,Race,S
+person,race_concept_id,38003613,Other Pacific Islander,Race,Race,Race,S
+person,race_concept_id,38003589,Pakistani,Race,Race,Race,S
+person,race_concept_id,38003610,Polynesian,Race,Race,Race,S
+person,race_concept_id,38003596,Singaporean,Race,Race,Race,S
+person,race_concept_id,38003590,Sri Lankan,Race,Race,Race,S
+person,race_concept_id,38003580,Taiwanese,Race,Race,Race,S
+person,race_concept_id,38003591,Thai,Race,Race,Race,S
+person,race_concept_id,38003607,Tobagoan,Race,Race,Race,S
+person,race_concept_id,38003608,Trinidadian,Race,Race,Race,S
+person,race_concept_id,38003592,Vietnamese,Race,Race,Race,S
+person,race_concept_id,38003609,West Indian,Race,Race,Race,S
+person,race_concept_id,8527,White,Race,Race,Race,S
+person,race_concept_id,4228069,Abyssinians,Race,SNOMED,Social Context,
+person,race_concept_id,4119705,Admiralty Islanders,Race,SNOMED,Social Context,
+person,race_concept_id,4035165,African American,Race,SNOMED,Social Context,
+person,race_concept_id,4211218,African race,Race,SNOMED,Social Context,
+person,race_concept_id,4184962,Afro-Caribbean,Race,SNOMED,Social Context,
+person,race_concept_id,4187747,Afro-Caucasian,Race,SNOMED,Social Context,
+person,race_concept_id,4100645,Ainu,Race,SNOMED,Social Context,
+person,race_concept_id,4231129,Alacaluf,Race,SNOMED,Social Context,
+person,race_concept_id,4050100,Aleuts,Race,SNOMED,Social Context,
+person,race_concept_id,4184966,American Indian or Alaska native,Race,SNOMED,Social Context,
+person,race_concept_id,4211331,American Indian race,Race,SNOMED,Social Context,
+person,race_concept_id,4281687,Amerind,Race,SNOMED,Social Context,
+person,race_concept_id,4175829,Andamanese,Race,SNOMED,Social Context,
+person,race_concept_id,4251760,Apache,Race,SNOMED,Social Context,
+person,race_concept_id,4231846,Arabs,Race,SNOMED,Social Context,
+person,race_concept_id,4014421,Armenians,Race,SNOMED,Social Context,
+person,race_concept_id,4201937,Asian - ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,4184984,Asian or Pacific islander,Race,SNOMED,Social Context,
+person,race_concept_id,4211353,Asian race,Race,SNOMED,Social Context,
+person,race_concept_id,4298833,Atacamenos,Race,SNOMED,Social Context,
+person,race_concept_id,4242388,Athabascans,Race,SNOMED,Social Context,
+person,race_concept_id,4183595,Australian Aborigines,Race,SNOMED,Social Context,
+person,race_concept_id,4186705,Australian aborigine,Race,SNOMED,Social Context,
+person,race_concept_id,4285116,Austrians,Race,SNOMED,Social Context,
+person,race_concept_id,4014099,Aymara,Race,SNOMED,Social Context,
+person,race_concept_id,4195705,Aztec,Race,SNOMED,Social Context,
+person,race_concept_id,4263311,Badagas,Race,SNOMED,Social Context,
+person,race_concept_id,45771426,Bajau,Race,SNOMED,Social Context,
+person,race_concept_id,45452880,Bangladeshi,Race,Read,Read,
+person,race_concept_id,4091018,Bangladeshi,Race,SNOMED,Social Context,
+person,race_concept_id,4219735,Bantu,Race,SNOMED,Social Context,
+person,race_concept_id,4240732,Barundi,Race,SNOMED,Social Context,
+person,race_concept_id,4163527,Basques,Race,SNOMED,Social Context,
+person,race_concept_id,4034654,Batutsi,Race,SNOMED,Social Context,
+person,race_concept_id,4210302,Belgians,Race,SNOMED,Social Context,
+person,race_concept_id,4102303,Bhutanese,Race,SNOMED,Social Context,
+person,race_concept_id,45767090,Bidayuh,Race,SNOMED,Social Context,
+person,race_concept_id,4201929,Black - ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,45496299,Black - other African country,Race,Read,Read,
+person,race_concept_id,4091011,Black - other African country,Race,SNOMED,Social Context,
+person,race_concept_id,45452879,Black - other Asian,Race,Read,Read,
+person,race_concept_id,4091012,Black - other Asian,Race,SNOMED,Social Context,
+person,race_concept_id,45502955,"Black - other, mixed",Race,Read,Read,
+person,race_concept_id,4091013,"Black - other, mixed",Race,SNOMED,Social Context,
+person,race_concept_id,45469811,Black African,Race,Read,Read,
+person,race_concept_id,4057568,Black African,Race,SNOMED,Social Context,
+person,race_concept_id,45499627,Black African and White,Race,Read,Read,
+person,race_concept_id,4153158,Black African and White,Race,SNOMED,Social Context,
+person,race_concept_id,45476450,Black Arab,Race,Read,Read,
+person,race_concept_id,4076901,Black Arab,Race,SNOMED,Social Context,
+person,race_concept_id,45429648,Black Black - other,Race,Read,Read,
+person,race_concept_id,45462994,Black British,Race,Read,Read,
+person,race_concept_id,4090389,Black British,Race,SNOMED,Social Context,
+person,race_concept_id,45496298,Black Caribbean,Race,Read,Read,
+person,race_concept_id,45522914,Black Caribbean,Race,Read,Read,
+person,race_concept_id,4087917,Black Caribbean,Race,SNOMED,Social Context,
+person,race_concept_id,45456221,Black Caribbean and White,Race,Read,Read,
+person,race_concept_id,4151776,Black Caribbean and White,Race,SNOMED,Social Context,
+person,race_concept_id,45522913,Black Caribbean/W.I./Guyana,Race,Read,Read,
+person,race_concept_id,4152832,Black Caribbean/W.I./Guyana,Race,SNOMED,Social Context,
+person,race_concept_id,45436284,Black E Afric Asia/Indo-Caribb,Race,Read,Read,
+person,race_concept_id,45479787,Black East African Asian,Race,Read,Read,
+person,race_concept_id,4078123,Black East African Asian,Race,SNOMED,Social Context,
+person,race_concept_id,4151577,Black East African Asian/Indo-Caribbean,Race,SNOMED,Social Context,
+person,race_concept_id,45446238,Black Guyana,Race,Read,Read,
+person,race_concept_id,4205380,Black Guyana,Race,SNOMED,Social Context,
+person,race_concept_id,45512960,Black Indian sub-continent,Race,Read,Read,
+person,race_concept_id,4085483,Black Indian sub-continent,Race,SNOMED,Social Context,
+person,race_concept_id,45462995,Black Indo-Caribbean,Race,Read,Read,
+person,race_concept_id,4078124,Black Indo-Caribbean,Race,SNOMED,Social Context,
+person,race_concept_id,45456219,Black Iranian,Race,Read,Read,
+person,race_concept_id,4077358,Black Iranian,Race,SNOMED,Social Context,
+person,race_concept_id,4305595,Black Jews,Race,SNOMED,Social Context,
+person,race_concept_id,45519603,Black N African/Arab/Iranian,Race,Read,Read,
+person,race_concept_id,4151576,Black N African/Arab/Iranian,Race,SNOMED,Social Context,
+person,race_concept_id,45429647,Black North African,Race,Read,Read,
+person,race_concept_id,4078122,Black North African,Race,SNOMED,Social Context,
+person,race_concept_id,45429646,Black West Indian,Race,Read,Read,
+person,race_concept_id,4203120,Black West Indian,Race,SNOMED,Social Context,
+person,race_concept_id,4211480,"Black, not of hispanic origin",Race,SNOMED,Social Context,
+person,race_concept_id,45516366,"Black, other, non-mixed origin",Race,Read,Read,
+person,race_concept_id,4091010,"Black, other, non-mixed origin",Race,SNOMED,Social Context,
+person,race_concept_id,4277901,Blackfeet,Race,SNOMED,Social Context,
+person,race_concept_id,4139924,Bloods,Race,SNOMED,Social Context,
+person,race_concept_id,4169399,Bogobos,Race,SNOMED,Social Context,
+person,race_concept_id,4301306,Bororo,Race,SNOMED,Social Context,
+person,race_concept_id,4218447,Brazilian Indians,Race,SNOMED,Social Context,
+person,race_concept_id,45436285,Brit. ethnic minor. spec.(NMO),Race,Read,Read,
+person,race_concept_id,45439570,Brit. ethnic minor. unsp (NMO),Race,Read,Read,
+person,race_concept_id,4090390,British ethnic minority specified,Race,SNOMED,Social Context,
+person,race_concept_id,4091019,British ethnic minority unspecified,Race,SNOMED,Social Context,
+person,race_concept_id,4264197,Bruneians,Race,SNOMED,Social Context,
+person,race_concept_id,45479793,Bulgarian,Race,Read,Read,
+person,race_concept_id,4167621,Bulgarian,Race,SNOMED,Social Context,
+person,race_concept_id,1397910,Bulgarian Roma,Race,Read,Read,
+person,race_concept_id,37394642,Bulgarian Roma,Race,SNOMED,Social Context,
+person,race_concept_id,36717066,Bulgarian Roma,Race,SNOMED,Social Context,
+person,race_concept_id,4221071,Buriats,Race,SNOMED,Social Context,
+person,race_concept_id,4309789,Bushmen,Race,SNOMED,Social Context,
+person,race_concept_id,4249154,Caingang,Race,SNOMED,Social Context,
+person,race_concept_id,37116650,Canadian,Race,SNOMED,Social Context,
+person,race_concept_id,4151578,Caribbean I./W.I./Guyana,Race,SNOMED,Social Context,
+person,race_concept_id,45479788,Caribbean I./W.I./Guyana (NMO),Race,Read,Read,
+person,race_concept_id,4077359,Caribbean Island,Race,SNOMED,Social Context,
+person,race_concept_id,45479789,Caribbean Island (NMO),Race,Read,Read,
+person,race_concept_id,4216433,Caroline Islanders,Race,SNOMED,Social Context,
+person,race_concept_id,4030411,Caucasian,Race,SNOMED,Social Context,
+person,race_concept_id,4185154,Caucasian,Race,SNOMED,Social Context,
+person,race_concept_id,4185155,"Caucasian, not of hispanic origin",Race,SNOMED,Social Context,
+person,race_concept_id,4211849,Chenchu,Race,SNOMED,Social Context,
+person,race_concept_id,45419859,Chinese,Race,Read,Read,
+person,race_concept_id,45476453,Chinese,Race,Read,Read,
+person,race_concept_id,4144377,Chinese,Race,SNOMED,Social Context,
+person,race_concept_id,4215810,Chippewa,Race,SNOMED,Social Context,
+person,race_concept_id,4270899,Choco,Race,SNOMED,Social Context,
+person,race_concept_id,4178142,Congolese,Race,SNOMED,Social Context,
+person,race_concept_id,45522915,Cook Island Maori,Race,Read,Read,
+person,race_concept_id,4087928,Cook Island Maori,Race,SNOMED,Social Context,
+person,race_concept_id,4012612,Coushatta,Race,SNOMED,Social Context,
+person,race_concept_id,4182121,Cuna,Race,SNOMED,Social Context,
+person,race_concept_id,45473117,Czech,Race,Read,Read,
+person,race_concept_id,4102622,Czech,Race,SNOMED,Social Context,
+person,race_concept_id,44803061,Czech,Race,SNOMED,Social Context,
+person,race_concept_id,1397642,Czech Roma,Race,Read,Read,
+person,race_concept_id,36713937,Czech Roma,Race,SNOMED,Social Context,
+person,race_concept_id,37394638,Czech Roma,Race,SNOMED,Social Context,
+person,race_concept_id,4031845,Danes,Race,SNOMED,Social Context,
+person,race_concept_id,4185580,Dieguenos,Race,SNOMED,Social Context,
+person,race_concept_id,4317261,Dutch,Race,SNOMED,Social Context,
+person,race_concept_id,4137597,Dyaks,Race,SNOMED,Social Context,
+person,race_concept_id,4148888,E Afric Asian/Indo-Carib,Race,SNOMED,Social Context,
+person,race_concept_id,45439571,E Afric Asian/Indo-Carib (NMO),Race,Read,Read,
+person,race_concept_id,4077381,East African Asian,Race,SNOMED,Social Context,
+person,race_concept_id,45516367,East African Asian (NMO),Race,Read,Read,
+person,race_concept_id,4103076,Easter Islanders,Race,SNOMED,Social Context,
+person,race_concept_id,4000051,Egyptians,Race,SNOMED,Social Context,
+person,race_concept_id,4247162,Ellice Islanders,Race,SNOMED,Social Context,
+person,race_concept_id,4093769,English,Race,SNOMED,Social Context,
+person,race_concept_id,4309952,Eskimo,Race,SNOMED,Social Context,
+person,race_concept_id,4090368,Estonians,Race,SNOMED,Social Context,
+person,race_concept_id,4155301,Ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,759814,Ethnic group unknown,Race,SNOMED,Social Context,
+person,race_concept_id,4273145,Ethnic groups (1991 census),Race,SNOMED,Social Context,
+person,race_concept_id,4212990,European,Race,SNOMED,Social Context,
+person,race_concept_id,4002414,Ewe,Race,SNOMED,Social Context,
+person,race_concept_id,45479791,Fijian,Race,Read,Read,
+person,race_concept_id,4321400,Fijian,Race,SNOMED,Social Context,
+person,race_concept_id,4296018,Filipinos,Race,SNOMED,Social Context,
+person,race_concept_id,4005076,Finns,Race,SNOMED,Social Context,
+person,race_concept_id,4027841,Flathead,Race,SNOMED,Social Context,
+person,race_concept_id,4024294,French,Race,SNOMED,Social Context,
+person,race_concept_id,4292111,Fulani,Race,SNOMED,Social Context,
+person,race_concept_id,4236027,Gambians,Race,SNOMED,Social Context,
+person,race_concept_id,4138072,Georgians,Race,SNOMED,Social Context,
+person,race_concept_id,4297319,Germans,Race,SNOMED,Social Context,
+person,race_concept_id,4292272,Ghanaians,Race,SNOMED,Social Context,
+person,race_concept_id,4233496,Ghashgai,Race,SNOMED,Social Context,
+person,race_concept_id,4171181,Gilbertese,Race,SNOMED,Social Context,
+person,race_concept_id,4076904,Greek,Race,SNOMED,Social Context,
+person,race_concept_id,45423089,Greek (NMO),Race,Read,Read,
+person,race_concept_id,4077361,Greek Cypriot,Race,SNOMED,Social Context,
+person,race_concept_id,45436287,Greek Cypriot (NMO),Race,Read,Read,
+person,race_concept_id,4152834,Greek/Greek Cypriot,Race,SNOMED,Social Context,
+person,race_concept_id,45462996,Greek/Greek Cypriot (NMO),Race,Read,Read,
+person,race_concept_id,4032635,Greeks,Race,SNOMED,Social Context,
+person,race_concept_id,4012103,Guamians,Race,SNOMED,Social Context,
+person,race_concept_id,4077360,Guyana,Race,SNOMED,Social Context,
+person,race_concept_id,45442862,Guyana (NMO),Race,Read,Read,
+person,race_concept_id,4221073,Gypsies,Race,SNOMED,Social Context,
+person,race_concept_id,4065367,Hawaiians,Race,SNOMED,Social Context,
+person,race_concept_id,4188159,Hispanic,Race,SNOMED,Social Context,
+person,race_concept_id,4190391,"Hispanic, black",Race,SNOMED,Social Context,
+person,race_concept_id,4188161,"Hispanic, color unknown",Race,SNOMED,Social Context,
+person,race_concept_id,4190392,"Hispanic, white",Race,SNOMED,Social Context,
+person,race_concept_id,4218288,Hobe,Race,SNOMED,Social Context,
+person,race_concept_id,4198993,Hottentot,Race,SNOMED,Social Context,
+person,race_concept_id,4279480,Huasteco,Race,SNOMED,Social Context,
+person,race_concept_id,4297991,Huichol,Race,SNOMED,Social Context,
+person,race_concept_id,4273384,Hungarian,Race,SNOMED,Social Context,
+person,race_concept_id,1398020,Hungarian Roma,Race,Read,Read,
+person,race_concept_id,36713940,Hungarian Roma,Race,SNOMED,Social Context,
+person,race_concept_id,37394639,Hungarian Roma,Race,SNOMED,Social Context,
+person,race_concept_id,4098866,Hututu,Race,SNOMED,Social Context,
+person,race_concept_id,45767091,Iban,Race,SNOMED,Social Context,
+person,race_concept_id,4245024,Ibo,Race,SNOMED,Social Context,
+person,race_concept_id,4248713,Icelanders,Race,SNOMED,Social Context,
+person,race_concept_id,4210186,Inca,Race,SNOMED,Social Context,
+person,race_concept_id,45483083,Indian,Race,Read,Read,
+person,race_concept_id,45446239,Indian,Race,Read,Read,
+person,race_concept_id,4091016,Indian,Race,SNOMED,Social Context,
+person,race_concept_id,4185920,Indian,Race,SNOMED,Social Context,
+person,race_concept_id,4090392,Indian sub-continent,Race,SNOMED,Social Context,
+person,race_concept_id,45476451,Indian sub-continent (NMO),Race,Read,Read,
+person,race_concept_id,4276043,Indians,Race,SNOMED,Social Context,
+person,race_concept_id,4076903,Indo-Caribbean,Race,SNOMED,Social Context,
+person,race_concept_id,45436286,Indo-Caribbean (NMO),Race,Read,Read,
+person,race_concept_id,4318647,Indonesians,Race,SNOMED,Social Context,
+person,race_concept_id,4289159,Irani,Race,SNOMED,Social Context,
+person,race_concept_id,4078125,Iranian,Race,SNOMED,Social Context,
+person,race_concept_id,45496301,Iranian (NMO),Race,Read,Read,
+person,race_concept_id,4100470,Iraqi,Race,SNOMED,Social Context,
+person,race_concept_id,4090393,Irish,Race,SNOMED,Social Context,
+person,race_concept_id,45419861,Irish (NMO),Race,Read,Read,
+person,race_concept_id,45512963,Irish traveller,Race,Read,Read,
+person,race_concept_id,4201938,Irish traveller,Race,SNOMED,Social Context,
+person,race_concept_id,4221856,Irula,Race,SNOMED,Social Context,
+person,race_concept_id,4135806,Italians,Race,SNOMED,Social Context,
+person,race_concept_id,4185935,Japanese,Race,SNOMED,Social Context,
+person,race_concept_id,4068834,Javanese,Race,SNOMED,Social Context,
+person,race_concept_id,45771425,Kadazan,Race,SNOMED,Social Context,
+person,race_concept_id,4048709,Kapingas,Race,SNOMED,Social Context,
+person,race_concept_id,4036536,Kenyans,Race,SNOMED,Social Context,
+person,race_concept_id,4218957,Kikuyu,Race,SNOMED,Social Context,
+person,race_concept_id,4180571,Kirghiz,Race,SNOMED,Social Context,
+person,race_concept_id,4243164,Koreans,Race,SNOMED,Social Context,
+person,race_concept_id,4298426,Kwakiutl,Race,SNOMED,Social Context,
+person,race_concept_id,4326740,Labradors,Race,SNOMED,Social Context,
+person,race_concept_id,4069284,Lacandon,Race,SNOMED,Social Context,
+person,race_concept_id,4282477,Lapps,Race,SNOMED,Social Context,
+person,race_concept_id,4240299,Liberians,Race,SNOMED,Social Context,
+person,race_concept_id,4308897,Luo,Race,SNOMED,Social Context,
+person,race_concept_id,4071025,Madagascans,Race,SNOMED,Social Context,
+person,race_concept_id,4028336,Malays,Race,SNOMED,Social Context,
+person,race_concept_id,4249883,Maori,Race,SNOMED,Social Context,
+person,race_concept_id,4327656,Mapuche,Race,SNOMED,Social Context,
+person,race_concept_id,4180729,Marathas,Race,SNOMED,Social Context,
+person,race_concept_id,4245756,Marshallese,Race,SNOMED,Social Context,
+person,race_concept_id,4269942,Maya,Race,SNOMED,Social Context,
+person,race_concept_id,45767088,Melanau,Race,SNOMED,Social Context,
+person,race_concept_id,4189474,Melanesian,Race,SNOMED,Social Context,
+person,race_concept_id,4053172,Melanesians,Race,SNOMED,Social Context,
+person,race_concept_id,4250319,Melanuans,Race,SNOMED,Social Context,
+person,race_concept_id,4186453,Mexican Indians,Race,SNOMED,Social Context,
+person,race_concept_id,4283895,Micronesians,Race,SNOMED,Social Context,
+person,race_concept_id,4196429,Mixed ethnic census group,Race,SNOMED,Social Context,
+person,race_concept_id,4212311,Mixed racial group,Race,SNOMED,Social Context,
+person,race_concept_id,4087322,Mongol,Race,SNOMED,Social Context,
+person,race_concept_id,4165388,Mozambiquans,Race,SNOMED,Social Context,
+person,race_concept_id,4283366,Msutu,Race,SNOMED,Social Context,
+person,race_concept_id,45767089,Murut,Race,SNOMED,Social Context,
+person,race_concept_id,4152833,N African Arab/Iranian,Race,SNOMED,Social Context,
+person,race_concept_id,45419860,N African Arab/Iranian (NMO),Race,Read,Read,
+person,race_concept_id,4217600,Naiars,Race,SNOMED,Social Context,
+person,race_concept_id,4186402,National surgical quality improvement program defined race unknown,Race,SNOMED,Social Context,
+person,race_concept_id,4212088,Navaho,Race,SNOMED,Social Context,
+person,race_concept_id,45459567,Nepali,Race,Read,Read,
+person,race_concept_id,44803976,Nepali,Race,SNOMED,Social Context,
+person,race_concept_id,4237214,New Britons,Race,SNOMED,Social Context,
+person,race_concept_id,4145762,New Caledonians,Race,SNOMED,Social Context,
+person,race_concept_id,4273538,New Hebrideans,Race,SNOMED,Social Context,
+person,race_concept_id,45486422,New Zealand European,Race,Read,Read,
+person,race_concept_id,4090521,New Zealand European,Race,SNOMED,Social Context,
+person,race_concept_id,45496302,New Zealand Maori,Race,Read,Read,
+person,race_concept_id,4091022,New Zealand Maori,Race,SNOMED,Social Context,
+person,race_concept_id,45499628,New Zealand ethnic group NOS,Race,Read,Read,
+person,race_concept_id,45442863,New Zealand ethnic groups,Race,Read,Read,
+person,race_concept_id,4087926,New Zealand ethnic groups,Race,SNOMED,Social Context,
+person,race_concept_id,4337671,Nez Percé,Race,SNOMED,Social Context,
+person,race_concept_id,4229603,Nigerians,Race,SNOMED,Social Context,
+person,race_concept_id,45509567,Niuean,Race,Read,Read,
+person,race_concept_id,4085489,Niuean,Race,SNOMED,Social Context,
+person,race_concept_id,9178,Non-white,Race,Race,Race,
+person,race_concept_id,4077346,North African Arab,Race,SNOMED,Social Context,
+person,race_concept_id,45449500,North African Arab (NMO),Race,Read,Read,
+person,race_concept_id,4063377,Norwegians,Race,SNOMED,Social Context,
+person,race_concept_id,4085322,Oceanian,Race,SNOMED,Social Context,
+person,race_concept_id,4017926,Onge,Race,SNOMED,Social Context,
+person,race_concept_id,45767087,Orang asli,Race,SNOMED,Social Context,
+person,race_concept_id,4235464,Oraons,Race,SNOMED,Social Context,
+person,race_concept_id,4189785,Oriental,Race,SNOMED,Social Context,
+person,race_concept_id,4199011,Oriental Jews,Race,SNOMED,Social Context,
+person,race_concept_id,4090391,Other African countries,Race,SNOMED,Social Context,
+person,race_concept_id,45469812,Other African countries (NMO),Race,Read,Read,
+person,race_concept_id,45473116,Other Asian,Race,Read,Read,
+person,race_concept_id,4087922,Other Asian,Race,SNOMED,Social Context,
+person,race_concept_id,45466387,Other Asian (NMO),Race,Read,Read,
+person,race_concept_id,45512962,Other Asian ethnic group,Race,Read,Read,
+person,race_concept_id,4199940,Other Asian ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,45496300,Other Black - Black/Asian orig,Race,Read,Read,
+person,race_concept_id,4087920,Other Black - Black/Asian orig,Race,SNOMED,Social Context,
+person,race_concept_id,45506204,Other Black - Black/White orig,Race,Read,Read,
+person,race_concept_id,4087919,Other Black - Black/White orig,Race,SNOMED,Social Context,
+person,race_concept_id,4090516,Other European,Race,SNOMED,Social Context,
+person,race_concept_id,45459564,Other European (NMO),Race,Read,Read,
+person,race_concept_id,45506206,Other European in New Zealand,Race,Read,Read,
+person,race_concept_id,4085488,Other European in New Zealand,Race,SNOMED,Social Context,
+person,race_concept_id,45442864,Other New Zealand ethnic group,Race,Read,Read,
+person,race_concept_id,45502956,Other Pacific ethnic group,Race,Read,Read,
+person,race_concept_id,8522,Other Race,Race,Race,Race,
+person,race_concept_id,45462997,Other black ethnic group,Race,Read,Read,
+person,race_concept_id,4202555,Other black ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,45449501,Other ethnic NEC (NMO),Race,Read,Read,
+person,race_concept_id,45483082,Other ethnic group,Race,Read,Read,
+person,race_concept_id,4087921,Other ethnic non-mixed,Race,SNOMED,Social Context,
+person,race_concept_id,45466386,Other ethnic non-mixed (NMO),Race,Read,Read,
+person,race_concept_id,45459565,"Other ethnic, Asian/White orig",Race,Read,Read,
+person,race_concept_id,4091021,"Other ethnic, Asian/White origin",Race,SNOMED,Social Context,
+person,race_concept_id,45429649,"Other ethnic, Black/White orig",Race,Read,Read,
+person,race_concept_id,4085487,"Other ethnic, Black/White origin",Race,SNOMED,Social Context,
+person,race_concept_id,45456220,"Other ethnic, mixed origin",Race,Read,Read,
+person,race_concept_id,4091020,"Other ethnic, mixed origin",Race,SNOMED,Social Context,
+person,race_concept_id,45423090,"Other ethnic, mixed white orig",Race,Read,Read,
+person,race_concept_id,4087924,"Other ethnic, mixed white origin",Race,SNOMED,Social Context,
+person,race_concept_id,45506205,"Other ethnic, other mixed orig",Race,Read,Read,
+person,race_concept_id,4090518,"Other ethnic, other mixed origin",Race,SNOMED,Social Context,
+person,race_concept_id,45436283,Other white British ethnic group,Race,Read,Read,
+person,race_concept_id,4268433,Other white British ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,45459563,Other white ethnic group,Race,Read,Read,
+person,race_concept_id,4099457,Paez,Race,SNOMED,Social Context,
+person,race_concept_id,45492990,Pakeha,Race,Read,Read,
+person,race_concept_id,45512961,Pakistani,Race,Read,Read,
+person,race_concept_id,4091017,Pakistani,Race,SNOMED,Social Context,
+person,race_concept_id,4216519,Pakistani,Race,SNOMED,Social Context,
+person,race_concept_id,4234343,Palauans,Race,SNOMED,Social Context,
+person,race_concept_id,4073535,Papuans,Race,SNOMED,Social Context,
+person,race_concept_id,4217467,Pehuenches,Race,SNOMED,Social Context,
+person,race_concept_id,4102599,Poles,Race,SNOMED,Social Context,
+person,race_concept_id,1397643,Polish Roma,Race,Read,Read,
+person,race_concept_id,37394640,Polish Roma,Race,SNOMED,Social Context,
+person,race_concept_id,36713941,Polish Roma,Race,SNOMED,Social Context,
+person,race_concept_id,4053167,Polynesians,Race,SNOMED,Social Context,
+person,race_concept_id,45469813,Portuguese,Race,Read,Read,
+person,race_concept_id,4213463,Portuguese,Race,SNOMED,Social Context,
+person,race_concept_id,4140692,Pueblo,Race,SNOMED,Social Context,
+person,race_concept_id,45767086,Punjabi,Race,SNOMED,Social Context,
+person,race_concept_id,4323551,Pygmies,Race,SNOMED,Social Context,
+person,race_concept_id,4194076,Quechua,Race,SNOMED,Social Context,
+person,race_concept_id,45528619,RACE AFRICAN,Race,OXMIS,OXMIS,
+person,race_concept_id,45529590,RACE ASIAN,Race,OXMIS,OXMIS,
+person,race_concept_id,45526661,RACE WEST INDIAN,Race,OXMIS,OXMIS,
+person,race_concept_id,45532670,RACE WHITE,Race,OXMIS,OXMIS,
+person,race_concept_id,45428285,RACE: Afro-caribbean,Race,Read,Read,
+person,race_concept_id,45501542,RACE: Afro-caucasian,Race,Read,Read,
+person,race_concept_id,45451482,RACE: Arab,Race,Read,Read,
+person,race_concept_id,45458163,RACE: Bangladeshi,Race,Read,Read,
+person,race_concept_id,45514934,RACE: Caucasian,Race,Read,Read,
+person,race_concept_id,45421717,RACE: Chinese,Race,Read,Read,
+person,race_concept_id,45441530,RACE: Japanese,Race,Read,Read,
+person,race_concept_id,45504866,RACE: Korean,Race,Read,Read,
+person,race_concept_id,45501541,RACE: Mixed,Race,Read,Read,
+person,race_concept_id,45518249,RACE: Not stated,Race,Read,Read,
+person,race_concept_id,45421718,RACE: Oriental,Race,Read,Read,
+person,race_concept_id,45511540,RACE: Pakistani,Race,Read,Read,
+person,race_concept_id,45431577,RACE: Unknown,Race,Read,Read,
+person,race_concept_id,45511539,RACE: West indian,Race,Read,Read,
+person,race_concept_id,45478359,RACE: White,Race,Read,Read,
+person,race_concept_id,4190758,Race not stated,Race,SNOMED,Social Context,
+person,race_concept_id,4051279,Race: West indian,Race,SNOMED,Clinical Finding,
+person,race_concept_id,4216292,Racial group,Race,SNOMED,Social Context,
+person,race_concept_id,36717683,Roma,Race,SNOMED,Social Context,
+person,race_concept_id,1397856,Roma ethnic group,Race,Read,Read,
+person,race_concept_id,37398747,Roma ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,45439572,Romanian,Race,Read,Read,
+person,race_concept_id,40483304,Romanian,Race,SNOMED,Social Context,
+person,race_concept_id,1397881,Romanian Roma,Race,Read,Read,
+person,race_concept_id,37394641,Romanian Roma,Race,SNOMED,Social Context,
+person,race_concept_id,36713938,Romanian Roma,Race,SNOMED,Social Context,
+person,race_concept_id,4309511,Russians,Race,SNOMED,Social Context,
+person,race_concept_id,4077735,Saipanese,Race,SNOMED,Social Context,
+person,race_concept_id,45516368,Samoan,Race,Read,Read,
+person,race_concept_id,4313587,Samoan,Race,SNOMED,Social Context,
+person,race_concept_id,42536269,Scandinavian,Race,SNOMED,Social Context,
+person,race_concept_id,4170372,Seminole,Race,SNOMED,Social Context,
+person,race_concept_id,4244365,Senegalese,Race,SNOMED,Social Context,
+person,race_concept_id,4198417,Senoi,Race,SNOMED,Social Context,
+person,race_concept_id,4201594,Serbs,Race,SNOMED,Social Context,
+person,race_concept_id,4219475,Shona,Race,SNOMED,Social Context,
+person,race_concept_id,4317523,Shoshone,Race,SNOMED,Social Context,
+person,race_concept_id,4103243,Siamese,Race,SNOMED,Social Context,
+person,race_concept_id,45483084,Slovak,Race,Read,Read,
+person,race_concept_id,44813053,Slovak,Race,SNOMED,Social Context,
+person,race_concept_id,4267217,Slovak,Race,SNOMED,Social Context,
+person,race_concept_id,1397882,Slovak Roma,Race,Read,Read,
+person,race_concept_id,36713939,Slovak Roma,Race,SNOMED,Social Context,
+person,race_concept_id,37394635,Slovak Roma,Race,SNOMED,Social Context,
+person,race_concept_id,4167520,Solomon Islanders,Race,SNOMED,Social Context,
+person,race_concept_id,4263713,Somalis,Race,SNOMED,Social Context,
+person,race_concept_id,4030302,South Asian AND/OR Australian aborigine,Race,SNOMED,Social Context,
+person,race_concept_id,4095109,South Asian Aborigine,Race,SNOMED,Social Context,
+person,race_concept_id,45479792,South East Asian,Race,Read,Read,
+person,race_concept_id,4087930,South East Asian,Race,SNOMED,Social Context,
+person,race_concept_id,4152781,Spaniards,Race,SNOMED,Social Context,
+person,race_concept_id,4229453,Sudanese,Race,SNOMED,Social Context,
+person,race_concept_id,4216818,Swedes,Race,SNOMED,Social Context,
+person,race_concept_id,4297790,Swiss,Race,SNOMED,Social Context,
+person,race_concept_id,4241969,Syrians,Race,SNOMED,Social Context,
+person,race_concept_id,4270900,Taiwanese,Race,SNOMED,Social Context,
+person,race_concept_id,4053816,Tamils,Race,SNOMED,Social Context,
+person,race_concept_id,4028346,Tanganyikans,Race,SNOMED,Social Context,
+person,race_concept_id,4235433,Tatars,Race,SNOMED,Social Context,
+person,race_concept_id,4308112,Thais,Race,SNOMED,Social Context,
+person,race_concept_id,4192497,Toba,Race,SNOMED,Social Context,
+person,race_concept_id,4216036,Todas,Race,SNOMED,Social Context,
+person,race_concept_id,45449503,Tokelauan,Race,Read,Read,
+person,race_concept_id,4091023,Tokelauan,Race,SNOMED,Social Context,
+person,race_concept_id,45459566,Tongan,Race,Read,Read,
+person,race_concept_id,4304542,Tongan,Race,SNOMED,Social Context,
+person,race_concept_id,45432962,Traveller - gypsy,Race,Read,Read,
+person,race_concept_id,4097690,Tristan da Cunhans,Race,SNOMED,Social Context,
+person,race_concept_id,4141462,Trukese,Race,SNOMED,Social Context,
+person,race_concept_id,4076905,Turkish,Race,SNOMED,Social Context,
+person,race_concept_id,45419862,Turkish (NMO),Race,Read,Read,
+person,race_concept_id,4078126,Turkish Cypriot,Race,SNOMED,Social Context,
+person,race_concept_id,45479790,Turkish Cypriot (NMO),Race,Read,Read,
+person,race_concept_id,4155521,Turkish/Turkish Cypriot,Race,SNOMED,Social Context,
+person,race_concept_id,45509566,Turkish/Turkish Cypriot (NMO),Race,Read,Read,
+person,race_concept_id,4195322,Turks,Race,SNOMED,Social Context,
+person,race_concept_id,4030735,Tutsi,Race,SNOMED,Social Context,
+person,race_concept_id,4296606,Ugandans,Race,SNOMED,Social Context,
+person,race_concept_id,37116384,Ukrainian,Race,SNOMED,Social Context,
+person,race_concept_id,8552,Unknown,Race,Race,Race,
+person,race_concept_id,4218674,Unknown racial group,Race,SNOMED,Social Context,
+person,race_concept_id,4148384,Utes,Race,SNOMED,Social Context,
+person,race_concept_id,4269914,Venezuelan Indians,Race,SNOMED,Social Context,
+person,race_concept_id,45489704,Vietnamese,Race,Read,Read,
+person,race_concept_id,4210116,Vietnamese,Race,SNOMED,Social Context,
+person,race_concept_id,4033391,Welsh,Race,SNOMED,Social Context,
+person,race_concept_id,4216026,West Africans,Race,SNOMED,Social Context,
+person,race_concept_id,4076902,West Indian,Race,SNOMED,Social Context,
+person,race_concept_id,45446240,West Indian (NMO),Race,Read,Read,
+person,race_concept_id,45442861,White,Race,Read,Read,
+person,race_concept_id,4090388,White - ethnic group,Race,SNOMED,Social Context,
+person,race_concept_id,45519602,White British,Race,Read,Read,
+person,race_concept_id,4196428,White British,Race,SNOMED,Social Context,
+person,race_concept_id,45479786,White Irish,Race,Read,Read,
+person,race_concept_id,4201928,White Irish,Race,SNOMED,Social Context,
+person,race_concept_id,45462993,White Scottish,Race,Read,Read,
+person,race_concept_id,4268432,White Scottish,Race,SNOMED,Social Context,
+person,race_concept_id,4092681,Xavante,Race,SNOMED,Social Context,
+person,race_concept_id,4214735,Xosa,Race,SNOMED,Social Context,
+person,race_concept_id,4295144,Yanomama,Race,SNOMED,Social Context,
+person,race_concept_id,4170060,Yapese,Race,SNOMED,Social Context,
+person,race_concept_id,45456222,Yemeni,Race,Read,Read,
+person,race_concept_id,44791722,Yemeni,Race,SNOMED,Social Context,
+person,race_concept_id,4296997,Zulu,Race,SNOMED,Social Context,
+procedure_occurrence,procedure_type_concept_id,45756909,Carrier claim detail - 10th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756910,Carrier claim detail - 11th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756911,Carrier claim detail - 12th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756912,Carrier claim detail - 13th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756900,Carrier claim detail - 1st position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756901,Carrier claim detail - 2nd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756902,Carrier claim detail - 3rd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756903,Carrier claim detail - 4th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756904,Carrier claim detail - 5th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756905,Carrier claim detail - 6th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756906,Carrier claim detail - 7th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756907,Carrier claim detail - 8th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756908,Carrier claim detail - 9th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,42865906,Condition Procedure,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000275,EHR order list entry,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,42865905,Facility header,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,257,Hospitalization Cost Record,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,32468,Inferred from claim,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000249,Inpatient detail - 1st position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000248,Inpatient detail - primary position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000260,Inpatient header - 10th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000261,Inpatient header - 11th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000262,Inpatient header - 12th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000263,Inpatient header - 13th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000264,Inpatient header - 14th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000265,Inpatient header - 15th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000251,Inpatient header - 1st position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000252,Inpatient header - 2nd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000253,Inpatient header - 3rd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000254,Inpatient header - 4th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000255,Inpatient header - 5th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000256,Inpatient header - 6th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000257,Inpatient header - 7th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000258,Inpatient header - 8th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000259,Inpatient header - 9th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000250,Inpatient header - primary position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,32425,NLP derived,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756864,Outpatient detail - 10th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756865,Outpatient detail - 11th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756866,Outpatient detail - 12th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756867,Outpatient detail - 13th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756868,Outpatient detail - 14th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756869,Outpatient detail - 15th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756870,Outpatient detail - 16th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756871,Outpatient detail - 17th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756872,Outpatient detail - 18th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756873,Outpatient detail - 19th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000267,Outpatient detail - 1st position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756874,Outpatient detail - 20th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756875,Outpatient detail - 21th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756876,Outpatient detail - 22th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756877,Outpatient detail - 23th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756878,Outpatient detail - 24th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756879,Outpatient detail - 25th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756880,Outpatient detail - 26th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756881,Outpatient detail - 27th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756882,Outpatient detail - 28th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756883,Outpatient detail - 29th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756856,Outpatient detail - 2nd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756884,Outpatient detail - 30th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756885,Outpatient detail - 31th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756886,Outpatient detail - 32th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756887,Outpatient detail - 33th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756888,Outpatient detail - 34th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756889,Outpatient detail - 35th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756890,Outpatient detail - 36th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756891,Outpatient detail - 37th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756892,Outpatient detail - 38th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756893,Outpatient detail - 39th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756857,Outpatient detail - 3rd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756894,Outpatient detail - 40th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756895,Outpatient detail - 41th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756896,Outpatient detail - 42th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756897,Outpatient detail - 43th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756898,Outpatient detail - 44th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756899,Outpatient detail - 45th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756858,Outpatient detail - 4th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756859,Outpatient detail - 5th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756860,Outpatient detail - 6th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756861,Outpatient detail - 7th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756862,Outpatient detail - 8th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,45756863,Outpatient detail - 9th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000266,Outpatient detail - primary position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000269,Outpatient header - 1st position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000270,Outpatient header - 2nd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000271,Outpatient header - 3rd position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000272,Outpatient header - 4th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000273,Outpatient header - 5th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000274,Outpatient header - 6th position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38000268,Outpatient header - primary position,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,43542354,Physician administered drug (identified as procedure),Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,44786630,Primary Procedure,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,581412,Procedure Recorded from a Survey,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38003622,Procedure recorded as diagnostic code,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,38003621,Procedure recorded as lab test,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,42898141,Referral record,Type Concept,Procedure Type,Procedure Type,S
+procedure_occurrence,procedure_type_concept_id,44786631,Secondary Procedure,Type Concept,Procedure Type,Procedure Type,S
+specimen,specimen_type_concept_id,581378,EHR Detail,Type Concept,Specimen Type,Specimen Type,S
+visit_occurrence,visit_concept_id,38004307,Adult Care Home,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8882,Adult Living Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004354,Air Transport Ambulance,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004364,Air Transportation Carrier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004305,Alzheimer Nursing Center (Dementia Center),Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004353,Ambulance,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8850,Ambulance - Air or Water,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8668,Ambulance - Land,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,581478,Ambulance Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004232,Ambulatory Adolescent and Children Mental Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004210,Ambulatory Adult Day Care Center/Clinic,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004231,Ambulatory Adult Mental Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004211,Ambulatory Amputee Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004213,Ambulatory Augmentative Communication Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004256,Ambulatory Cardiac Rehabilitation Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004207,Ambulatory Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004216,Ambulatory Community Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004217,Ambulatory Corporate Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004215,Ambulatory Critical Access Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004218,Ambulatory Dental Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004219,Ambulatory Developmental Disabilities Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004220,Ambulatory Emergency Care Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004222,Ambulatory Endoscopy Cinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004208,Ambulatory Family Planning Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004243,Ambulatory Federal Public Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004209,Ambulatory Fertility Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004225,Ambulatory Genetics Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004226,Ambulatory Health Service Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004227,Ambulatory Hearing and Speech Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004228,Ambulatory Infusion Therapy Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004229,Ambulatory Lithotripsy Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004238,Ambulatory Magnetic Resonance Imaging (MRI) Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004251,Ambulatory Mammography Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004240,Ambulatory Medical Specialty Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004242,Ambulatory Medically Fragile Intants and Children Day Care Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004241,Ambulatory Methadone Clinic,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004233,Ambulatory Migrant Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004237,Ambulatory Military Ambulatory Procedure Visits Operational (Transportable) Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004236,Ambulatory Military Outpatient Operational (Transportable) Component Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004235,Ambulatory Military and U.S. Coast Guard Ambulatory Procedure Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004234,Ambulatory Military/U.S. Coast Guard Outpatient Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004252,Ambulatory Mobile Mammography Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004253,Ambulatory Mobile Radiology Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004239,Ambulatory Multi-Specialty Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004223,Ambulatory Non-Surgical Family Planning Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004267,Ambulatory Occupational Medicine Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004269,Ambulatory Oncological Radiation Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004268,Ambulatory Oncology Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004262,Ambulatory Ophthalmologic Surgery Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004261,Ambulatory Oral and Maxillofacial Surgery Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004249,Ambulatory Pain Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004246,Ambulatory Physical Therapy Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004245,Ambulatory Podiatric Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004247,Ambulatory Primary Care Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004248,Ambulatory Prison Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004250,Ambulatory Radiology Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004258,Ambulatory Recovery Care Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004254,Ambulatory Rehabilitation Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,581479,Ambulatory Rehabilitation Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004259,Ambulatory Research Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004260,Ambulatory Rural Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004264,Ambulatory Sleep Disorder Diagnostic Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004244,Ambulatory State or Local Public Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004263,Ambulatory Student Health Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004257,Ambulatory Substance Use Disorder Rehabilitation Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8883,Ambulatory Surgical Center,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004266,Ambulatory VA Clinic/Center,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8615,Assisted Living Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004121,Assistive Technology Audiology Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004303,Behavioral Disturbances Assisted Living Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8650,Birthing Center,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004322,Blood Bank Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004365,Bus,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004193,Case Management Visit,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004442,Child Mental Illness Respite Care,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004443,Child Mental Retardation and/or Developmental Disability Respite Care,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004444,Child Physical Disability Respite Care,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004276,Chronic Disease Children Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004275,Chronic Disease Hospital Unit,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004339,Clinic Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004693,Clinic or Group Practice,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004294,Clinical Medical Laboratory,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004197,Community Based Hospice Care Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004317,Community Based Mental Retardation and Developmental Disabilities Residential Treatment Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004316,Community Based Residential Mental Illness Treatment Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8964,Community Mental Health Center,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,903270,Community health services dental,Visit,HES Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004340,Community/Retail Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004341,Compounding Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8920,Comprehensive Inpatient Rehabilitation Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8947,Comprehensive Outpatient Rehabilitation Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,32276,Critical Access Hospital,Visit,UB04 Typ bill,Visit,S
+visit_occurrence,visit_concept_id,8827,Custodial Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004306,Custodial Care Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004328,Customized Equipment Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004295,Dental Laboratory,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004522,Department Store,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004324,Department of Veterans Affairs (VA) Pharmacy Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004194,Developmentally Disabled Service Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004329,Dialysis Equipment Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004327,Durable Medical Equipment Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004204,Early Intervention Provider Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004337,Emergency Response System Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8870,Emergency Room - Hospital,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,581381,Emergency Room Critical Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,9203,Emergency Room Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,262,Emergency Room and Inpatient Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,8949,End-Stage Renal Disease Treatment Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004270,Epilepsy Hospital Unit,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004333,Eye Bank Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004334,Eyewear Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004453,Family Practice,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,8966,Federally Qualified Health Center,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004205,Foster Care Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004281,General Acute Care Children Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004280,General Acute Care Critical Access Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004279,General Acute Care Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004283,General Acute Care Women Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004282,General Rural Acute Care Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004523,Grocery Store,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,8851,Group Home,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38003820,"Group, Multi-Specialty",Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38003821,"Group, Single Specialty",Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,32693,Health examination,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004335,Hearing Aid Equipment Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004336,Home Delivered Meal Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004519,Home Health Agency,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004196,Home Infusion Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004342,Home Infusion Therapy Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,581476,Home Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,8672,Homeless Shelter,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8546,Hospice,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004515,Hospital,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,32254,Hospital-Swing Beds,Visit,UB04 Typ bill,Visit,S
+visit_occurrence,visit_concept_id,38004206,In Home Supportive Care Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8716,Independent Clinic,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004678,Independent Diagnostic Testing Facility,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,8809,Independent Laboratory,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8968,Indian Health Service Free-standing Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8969,Indian Health Service Provider-based Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004702,Indian Health Service facility,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004325,Indian Health Service/Tribal/Urban Indian Health (I/T/U) Pharmacy Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,581383,Inpatient Cardiac Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,581379,Inpatient Critical Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004311,Inpatient Hospice,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8717,Inpatient Hospital,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,581384,Inpatient Nursery,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8971,Inpatient Psychiatric Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,9201,Inpatient Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004343,Institutional Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,32037,Intensive Care,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,8951,Intermediate Mental Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,32036,Laboratory Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004192,Local Education Agency (LEA),Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004277,Long Term Care Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004344,Long Term Care Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004345,Mail Order Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004677,Mammography Center,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004346,Managed Care Organization Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8858,Mass Immunization Center,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004350,Medical Food Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004680,Medical Supply Company with Orthotist,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004682,Medical Supply Company with Orthotist-Prosthetist,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004525,Medical Supply Company with Pedorthic Personnel,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004687,Medical Supply Company with Pharmacist,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004681,Medical Supply Company with Prosthetist,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004521,Medical Supply Company with Respiratory Therapist,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004302,Mental Illness Assisted Living Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004293,Military Clinical Medical Laboratory,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004290,Military General Acute Care Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004291,Military General Acute Care Operational (Transportable) Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004288,Military Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8905,Military Treatment Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004323,Military/U.S. Coast Guard Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004357,Military/U.S. Coast Guard Transport,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004359,"Military/U.S. Coast Guard Transport, Military or U.S. Coast Guard Air Ambulance",Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004358,"Military/U.S. Coast Guard Transport, Military or U.S. Coast Guard Ground Transport Ambulance",Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004360,"Military/U.S. Coast Guard Transport, Military or U.S. Coast Guard Water Ambulance",Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8584,Mobile Unit,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004326,Non-Pharmacy Dispensing Site Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004362,Non-emergency Medical Transport,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,42898160,Non-hospital institution Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,8974,Non-residential Substance Abuse Treatment Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004347,Nuclear Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004198,Nursing Care Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8676,Nursing Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004330,Nursing Facility Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,44777714,Nursing episode,Visit,HES Specialty,Visit,S
+visit_occurrence,visit_concept_id,581385,Observation Room,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,5084,Off Campus-Outpatient Hospital,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,581477,Office Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004351,Organ Procurement Organization,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004683,Other Medical Supply Company,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,581380,Outpatient Critical Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8756,Outpatient Hospital,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,32253,Outpatient Laboratory Visit,Visit,UB04 Typ bill,Visit,S
+visit_occurrence,visit_concept_id,9202,Outpatient Visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004332,Oxygen Equipment Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004703,Oxygen supplier,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004201,PACE Provider Organization,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004331,Parenteral and Enteral Nutrition Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004338,Pharmacy Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,581458,Pharmacy visit,Visit,Visit,Visit,S
+visit_occurrence,visit_concept_id,38004296,Physiological Laboratory,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,581475,Place of Employment-Worksite,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004691,Portable X-Ray Supplier,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004352,Portable X-Ray Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38003619,Prison/Correctional Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004366,Private Vehicle,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004349,Prosthetic/Orthotic Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8913,Psychiatric Facility-Partial Hospitalization,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004284,Psychiatric Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8976,Psychiatric Residential Treatment Center,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8977,Public Health Clinic,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004689,Public Health or Welfare Agency,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004199,Public Health or Welfare Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004696,Radiation Therapy Center,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004526,Rehabilitation Agency,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004074,Rehabilitation Assistive Technology Supplier,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004286,Rehabilitation Children Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004285,Rehabilitation Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,32261,Religious Non-medical Health Care Inst-Outpatient Services,Visit,UB04 Typ bill,Visit,S
+visit_occurrence,visit_concept_id,38004278,Religious Nonmedical Health Care Institution,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004321,Residential Children Substance Abuse Treatment Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004318,Residential Emotionally Disturbed Children Treatment Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004314,Residential Mental Retardation and Developmental Disabilities Treatment Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004315,Residential Physical Disabilities Treatment Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8957,Residential Substance Abuse Treatment Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004440,Respite Care,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004441,Respite Care Camp,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8761,Rural Health Clinic,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8537,School,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004361,Secured Medical Transport,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8863,Skilled Nursing Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004310,Skilled Pediatric Nursing Facility,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004697,Slide Preparation Facility,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004287,Special Hospital,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004348,Specialty Pharmacy,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004274,Substance Use Disorder Rehabilitation Hospital Unit,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004698,Supplier,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004203,Support Brokerage Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004363,Taxi,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,5083,Telehealth,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8602,Temporary Lodging,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004367,Train,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38004368,Transportation Broker,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,8941,Tribal 638 Free-standing Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8960,Tribal 638 Provider-based Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,8782,Urgent Care Facility,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004690,Voluntary Health or Charitable Agency,Visit,Medicare Specialty,Visit,S
+visit_occurrence,visit_concept_id,38004202,Voluntary or Charitable Agency,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,38003620,Walk-in Retail Health Clinic,Visit,CMS Place of Service,Visit,S
+visit_occurrence,visit_concept_id,38004356,Water Transport Ambulance,Visit,NUCC,Visit,S
+visit_occurrence,visit_concept_id,44777691,"Well babies (care given by the mother/substitute, with nursing advice if needed)",Visit,HES Specialty,Visit,S
+visit_occurrence,visit_concept_id,32217,Admitted as an inpatient to this hospital,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,38004200,"Agencies, Community/Behavioral Health",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004688,Ambulance Service Provider,Visit,Medicare Specialty,Visit,
+visit_occurrence,visit_concept_id,38004255,Ambulatory Comprehensive Outpatient Rehabilitation Facility (CORF),Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004224,Ambulatory Federally Qualified Health Center (FQHC),Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004212,"Ambulatory Health Care Facilities, Clinic/Center, Ambulatory Surgical",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004214,"Ambulatory Health Care Facilities, Clinic/Center, Birthing",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004221,"Ambulatory Health Care Facilities, Clinic/Center, End-Stage Renal Disease (ESRD) Treatment",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004265,"Ambulatory Health Care Facilities, Clinic/Center, Urgent Care",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004230,Ambulatory Mental Health Clinic/Center (Including Community Mental Health Center),Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32274,Ambulatory Surgery Center,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32156,Ambulatory Surgery Center@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32158,Ambulatory Surgery Center@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32157,Ambulatory Surgery Center@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32159,Ambulatory Surgery Center@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32160,Ambulatory Surgery Center@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32155,Ambulatory Surgery Center@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32161,Ambulatory Surgery Center@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32162,Ambulatory Surgery Center@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,38004679,Ambulatory Surgical Center,Visit,Medicare Specialty,Visit,
+visit_occurrence,visit_concept_id,44777700,Antenatal clinic,Visit,HES Specialty,Visit,
+visit_occurrence,visit_concept_id,32592,Born inside this hospital,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32593,Born outside this hospital,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,38004313,Christian Science Nursing Facility,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32194,Clinic or physicians office,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32090,Clinic- Hosp Based or Indep Renal Dialysis Center@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32097,Clinic- Hosp Based or Indep Renal Dialysis Center@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32099,Clinic- Hosp Based or Indep Renal Dialysis Center@Initiated Adjustment Claim-other,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32092,Clinic- Hosp Based or Indep Renal Dialysis Center@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32091,Clinic- Hosp Based or Indep Renal Dialysis Center@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32093,Clinic- Hosp Based or Indep Renal Dialysis Center@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32098,Clinic- Hosp Based or Indep Renal Dialysis Center@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32094,Clinic- Hosp Based or Indep Renal Dialysis Center@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32089,Clinic- Hosp Based or Indep Renal Dialysis Center@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32095,Clinic- Hosp Based or Indep Renal Dialysis Center@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32096,Clinic- Hosp Based or Indep Renal Dialysis Center@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32268,Clinic-Community Mental Health Center,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32124,Clinic-Community Mental Health Center@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32129,Clinic-Community Mental Health Center@Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32126,Clinic-Community Mental Health Center@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32125,Clinic-Community Mental Health Center@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32127,Clinic-Community Mental Health Center@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32123,Clinic-Community Mental Health Center@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32128,Clinic-Community Mental Health Center@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32267,Clinic-Comprehensive Outpatient Rehab (CORF),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32116,Clinic-Comprehensive Outpatient Rehab (CORF)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32121,Clinic-Comprehensive Outpatient Rehab (CORF)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32118,Clinic-Comprehensive Outpatient Rehab (CORF)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32117,Clinic-Comprehensive Outpatient Rehab (CORF)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32119,Clinic-Comprehensive Outpatient Rehab (CORF)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32122,Clinic-Comprehensive Outpatient Rehab (CORF)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32120,Clinic-Comprehensive Outpatient Rehab (CORF)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32269,Clinic-Federally Qualified Health Center (FQHC),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32130,Clinic-Federally Qualified Health Center (FQHC)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32134,Clinic-Federally Qualified Health Center (FQHC)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32131,Clinic-Federally Qualified Health Center (FQHC)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32132,Clinic-Federally Qualified Health Center (FQHC)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32133,Clinic-Federally Qualified Health Center (FQHC)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32265,Clinic-Freestanding,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32100,Clinic-Freestanding@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32102,Clinic-Freestanding@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32101,Clinic-Freestanding@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32103,Clinic-Freestanding@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32104,Clinic-Freestanding@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32271,Clinic-Other,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32137,Clinic-Other@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32139,Clinic-Other@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32138,Clinic-Other@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32140,Clinic-Other@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32136,Clinic-Other@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32141,Clinic-Other@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32266,Clinic-Outpatient Rehab Facility (ORF),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32106,Clinic-Outpatient Rehab Facility (ORF)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32114,Clinic-Outpatient Rehab Facility (ORF)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32113,Clinic-Outpatient Rehab Facility (ORF)@Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32108,Clinic-Outpatient Rehab Facility (ORF)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32107,Clinic-Outpatient Rehab Facility (ORF)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32109,Clinic-Outpatient Rehab Facility (ORF)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32115,Clinic-Outpatient Rehab Facility (ORF)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32110,Clinic-Outpatient Rehab Facility (ORF)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32105,Clinic-Outpatient Rehab Facility (ORF)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32111,Clinic-Outpatient Rehab Facility (ORF)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32112,Clinic-Outpatient Rehab Facility (ORF)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32263,Clinic-Rural Health,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32081,Clinic-Rural Health@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32086,Clinic-Rural Health@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32083,Clinic-Rural Health@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32082,Clinic-Rural Health@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32087,Clinic-Rural Health@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32088,Clinic-Rural Health@MSP Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32080,Clinic-Rural Health@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32084,Clinic-Rural Health@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32085,Clinic-Rural Health@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32198,Court/Law enforcement,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32165,Critical Access Hospital@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32171,Critical Access Hospital@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32167,Critical Access Hospital@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32166,Critical Access Hospital@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32168,Critical Access Hospital@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32172,Critical Access Hospital@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32169,Critical Access Hospital@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32164,Critical Access Hospital@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32170,Critical Access Hospital@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32598,Discharged for Other Reasons,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32599,Discharged to Care of Family/Friend(s),Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32600,Discharged to Care of Paid Caregiver,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32601,Discharged to Court/ Law Enforcement/Jail,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32602,Discharged to Other Facility per Legal Guidelines,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32235,Discharged to home or self-care with a planned acute care hospital readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32210,Discharged to home/self care (routine charge).,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32231,Discharged/Transferred to a psychiatric hospital or psychiatric distinct unit of a hospital,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32219,Discharged/transferred to Court/Law Enforcement,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32232,Discharged/transferred to a Critical Access Hospital (CAH),Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32245,Discharged/transferred to a Medicare certified long term care hospital (LTCH) with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32248,Discharged/transferred to a critical access hospital (CAH) with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32239,Discharged/transferred to a designated cancer center or children?s hospital with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32233,Discharged/transferred to a designated disaster alternative care site,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32238,Discharged/transferred to a facility that provides custodial or supportive care with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32242,Discharged/transferred to a federal health care facility with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32224,Discharged/transferred to a federal hospital,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32243,Discharged/transferred to a hospital-based Medicare approved swing bed with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32229,Discharged/transferred to a long term care hospitals,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32230,Discharged/transferred to a nursing facility certified under Medicaid but not under Medicare,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32247,Discharged/transferred to a psychiatric hospital/distinct part unit of a hospital with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32236,Discharged/transferred to a short term general hospital for inpatient care with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32237,Discharged/transferred to a skilled nursing facility (SNF) with Medicare certification with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32244,Discharged/transferred to an inpatient rehabilitation facility (IRF) including rehabilitation distinct part units of a hospital with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32228,Discharged/transferred to an inpatient rehabilitation facility including distinct parts units of a hospital,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32234,Discharged/transferred to another type of health care institution not defined elsewhere in code list.,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32249,Discharged/transferred to another type of health care institution not defined elsewhere in this code list with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32214,Discharged/transferred to another type of institution for inpatient care (designated cancer center or childrens hospital),Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32241,Discharged/transferred to court/law enforcement with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32215,Discharged/transferred to home care of organized home health service organization.,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32594,Discharged/transferred to home under care of Home IV provider,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32240,Discharged/transferred to home under care of organized home health service organization with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32213,Discharged/transferred to intermediate care facility (ICF).,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32246,Discharged/transferred to nursing facility certified under Medicaid but not certified under Medicare with a planned acute care hospital inpatient readmission,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32211,Discharged/transferred to other short term general hospital for inpatient care.,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32212,Discharged/transferred to skilled nursing facility (SNF) with Medicare certification in anticipation of covered skilled care,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32227,Discharged/transferred within this institution to a hospital-based Medicare approved swing bed,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32596,Discharged/transferred/referred another institution for outpatient services,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32597,Discharged/transferred/referred to this institution for outpatient services,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32603,Disharge required by Carrier Change,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32583,Emergency Room,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32218,Expired,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32223,Expired - place unknown (Hospice claims only),Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32221,Expired at home (hospice claims only),Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32222,"Expired in a medical facility such as hospital, SNF, ICF, or freestanding hospice. (Hospice claims only)",Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32590,Extramural Birth,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32287,Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32275,Freestanding Birthing Center,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32163,Freestanding Birthing Center@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32582,HMO Referral,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,8536,Home,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,38004195,Home Health Agency,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32258,Home Health-Inpatient (treatment Part B only),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32376,Home Health-Inpatient (treatment Part B only)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32383,Home Health-Inpatient (treatment Part B only)@Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32384,Home Health-Inpatient (treatment Part B only)@Initiated Adjustment Claim-other,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32378,Home Health-Inpatient (treatment Part B only)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32377,Home Health-Inpatient (treatment Part B only)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32379,Home Health-Inpatient (treatment Part B only)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32380,Home Health-Inpatient (treatment Part B only)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32375,Home Health-Inpatient (treatment Part B only)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32381,Home Health-Inpatient (treatment Part B only)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32382,Home Health-Inpatient (treatment Part B only)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32260,Home Health-Other (Med & Surg under plan of treatment),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32396,Home Health-Other (Med & Surg under plan of treatment)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32052,Home Health-Other (Med & Surg under plan of treatment)@Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32049,Home Health-Other (Med & Surg under plan of treatment)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32048,Home Health-Other (Med & Surg under plan of treatment)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32050,Home Health-Other (Med & Surg under plan of treatment)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32053,Home Health-Other (Med & Surg under plan of treatment)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32395,Home Health-Other (Med & Surg under plan of treatment)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32051,Home Health-Other (Med & Surg under plan of treatment)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32054,Home Health-Other (Med & Surg under plan of treatment)@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32259,"Home Health-Outpatient (Part A, Includes DME Part A)",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32386,"Home Health-Outpatient (Part A, Includes DME Part A)@Admit through Discharge Claim",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32393,"Home Health-Outpatient (Part A, Includes DME Part A)@Final Claim for a Home Health PPS Episode",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32388,"Home Health-Outpatient (Part A, Includes DME Part A)@Interim-Cont claim (b)",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32387,"Home Health-Outpatient (Part A, Includes DME Part A)@Interim-first claim",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32389,"Home Health-Outpatient (Part A, Includes DME Part A)@Interim-last claim (b)",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32390,"Home Health-Outpatient (Part A, Includes DME Part A)@Late Charges Only",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32394,"Home Health-Outpatient (Part A, Includes DME Part A)@MSP Initiated Adjustment Claim",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32385,"Home Health-Outpatient (Part A, Includes DME Part A)@Non-Payment/Zero",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32391,"Home Health-Outpatient (Part A, Includes DME Part A)@Replacement of Prior Claim",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32392,"Home Health-Outpatient (Part A, Includes DME Part A)@Void/ Cancel of Prior claim (a)",Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32193,Home/non health care facility point of origin,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32273,Hospice (hospital based),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32149,Hospice (hospital based)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32151,Hospice (hospital based)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32150,Hospice (hospital based)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32152,Hospice (hospital based)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32153,Hospice (hospital based)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32154,Hospice (hospital based)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32272,Hospice (non-hospital based),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32142,Hospice (non-hospital based)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32148,Hospice (non-hospital based)@Hospice/CMS Coord Care/Religious NonMed/Cent of ExcellenceDemonstration,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32144,Hospice (non-hospital based)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32143,Hospice (non-hospital based)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32145,Hospice (non-hospital based)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32146,Hospice (non-hospital based)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32147,Hospice (non-hospital based)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32225,Hospice - home,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32226,Hospice - medical facility,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32289,Hospice/CMS Coord Care/Religious NonMed/Cent of ExcellenceDemonstration,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32337,Hospital -Laboratory Services provided to non-pt@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32339,Hospital -Laboratory Services provided to non-pt@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32338,Hospital -Laboratory Services provided to non-pt@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32340,Hospital -Laboratory Services provided to non-pt@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32341,Hospital -Laboratory Services provided to non-pt@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32336,Hospital -Laboratory Services provided to non-pt@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32342,Hospital -Laboratory Services provided to non-pt@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32343,Hospital -Laboratory Services provided to non-pt@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32264,Hospital Based Clinic or Independent Renal Dialysis Center,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32250,Hospital Inpatient (Including Medicare Part A),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32300,Hospital Inpatient (Including Medicare Part A)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32307,Hospital Inpatient (Including Medicare Part A)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32302,Hospital Inpatient (Including Medicare Part A)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32301,Hospital Inpatient (Including Medicare Part A)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32303,Hospital Inpatient (Including Medicare Part A)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32308,Hospital Inpatient (Including Medicare Part A)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32304,Hospital Inpatient (Including Medicare Part A)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32299,Hospital Inpatient (Including Medicare Part A)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32310,Hospital Inpatient (Including Medicare Part A)@Replacement of Prior Abbreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32305,Hospital Inpatient (Including Medicare Part A)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32306,Hospital Inpatient (Including Medicare Part A)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32309,Hospital Inpatient (Including Medicare Part A)@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32251,Hospital Inpatient (Medicare Part B only),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32312,Hospital Inpatient (Medicare Part B only)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32314,Hospital Inpatient (Medicare Part B only)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32313,Hospital Inpatient (Medicare Part B only)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32315,Hospital Inpatient (Medicare Part B only)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32317,Hospital Inpatient (Medicare Part B only)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32311,Hospital Inpatient (Medicare Part B only)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32316,Hospital Inpatient (Medicare Part B only)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32252,Hospital Outpatient,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32319,Hospital Outpatient@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32329,Hospital Outpatient@CMS Initiated Adjustment,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32328,Hospital Outpatient@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32326,Hospital Outpatient@Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32331,Hospital Outpatient@Initiated Adjustment Claim-other,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32321,Hospital Outpatient@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32320,Hospital Outpatient@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32322,Hospital Outpatient@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32330,Hospital Outpatient@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32323,Hospital Outpatient@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32333,Hospital Outpatient@MSP Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32318,Hospital Outpatient@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32332,Hospital Outpatient@OIG Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32335,Hospital Outpatient@Replacement of Prior Abbreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32324,Hospital Outpatient@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32325,Hospital Outpatient@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32334,Hospital Outpatient@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32327,Hospital Outpatient@Void/Cancel Hospice/CMS Coor Care/Non-med Religious/Cent for Excellence,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32344,Hospital-Swing Beds@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32346,Hospital-Swing Beds@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32345,Hospital-Swing Beds@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32347,Hospital-Swing Beds@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32348,Hospital-Swing Beds@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,38004292,"Hospitals, Christian Science Sanitorium",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32199,Information not available,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,581382,Inpatient Intensive Care Facility,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,8970,Inpatient Long-term Care,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,32255,Inpatient Skilled Nursing Facility Visit,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,581399,Interactive Telemedicine Service,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,32401,Intermediate Care - Level 1 (Including Medicare Part A),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32057,Intermediate Care - Level 1 (Including Medicare Part A)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32064,Intermediate Care - Level 1 (Including Medicare Part A)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32059,Intermediate Care - Level 1 (Including Medicare Part A)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32058,Intermediate Care - Level 1 (Including Medicare Part A)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32060,Intermediate Care - Level 1 (Including Medicare Part A)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32065,Intermediate Care - Level 1 (Including Medicare Part A)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32061,Intermediate Care - Level 1 (Including Medicare Part A)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32056,Intermediate Care - Level 1 (Including Medicare Part A)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32067,Intermediate Care - Level 1 (Including Medicare Part A)@Replacement of Prior Abbreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32062,Intermediate Care - Level 1 (Including Medicare Part A)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32063,Intermediate Care - Level 1 (Including Medicare Part A)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32066,Intermediate Care - Level 1 (Including Medicare Part A)@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32402,Intermediate Care - Level 2 (Including Medicare Part A),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32069,Intermediate Care - Level 2 (Including Medicare Part A)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32076,Intermediate Care - Level 2 (Including Medicare Part A)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32071,Intermediate Care - Level 2 (Including Medicare Part A)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32070,Intermediate Care - Level 2 (Including Medicare Part A)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32072,Intermediate Care - Level 2 (Including Medicare Part A)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32077,Intermediate Care - Level 2 (Including Medicare Part A)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32073,Intermediate Care - Level 2 (Including Medicare Part A)@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32068,Intermediate Care - Level 2 (Including Medicare Part A)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32079,Intermediate Care - Level 2 (Including Medicare Part A)@Replacement of Prior Abbreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32074,Intermediate Care - Level 2 (Including Medicare Part A)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32075,Intermediate Care - Level 2 (Including Medicare Part A)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32078,Intermediate Care - Level 2 (Including Medicare Part A)@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,38004517,Intermediate Care Nursing Facility,Visit,Medicare Specialty,Visit,
+visit_occurrence,visit_concept_id,38004304,Intermediate Mental Care Facility,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32604,Internal Transfer per Legal Guidelines,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,44777715,Joint consultant clinic,Visit,HES Specialty,Visit,
+visit_occurrence,visit_concept_id,38004355,Land Transport Ambulance,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32216,Left against medical advice or discontinued care.,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32270,Licensed Freestanding Emergency Medical Facility,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32135,Licensed Freestanding Emergency Medical Facility@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,38004273,Medicare Defined Swing Bed Hospital Unit,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004289,Military Community Health Hospital,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32595,Neonate discharged to another hospital for neonatal aftercare,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32587,Normal Delivery,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32591,Not Available,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,38004301,"Nursing & Custodial Care Facilities, Assisted Living Facility",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004312,"Nursing & Custodial Care Facilities, Intermediate Care Facility, Mentally Retarded",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004308,"Nursing & Custodial Care Facilities, Nursing Facility/Intermediate Care Facility",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004309,"Nursing & Custodial Care Facilities, Skilled Nursing Facility",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,8940,Office,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,32605,Other Home Care,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,8892,Other Inpatient Care,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,38004518,Other Nursing Facility,Visit,Medicare Specialty,Visit,
+visit_occurrence,visit_concept_id,8844,Other Place of Service,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,8677,Outpatient NEC,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,32257,Outpatient Skilled Nursing Facility Visit,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,8562,Pharmacy,Visit,CMS Place of Service,Visit,
+visit_occurrence,visit_concept_id,38004520,Pharmacy,Visit,Medicare Specialty,Visit,
+visit_occurrence,visit_concept_id,44777701,Postnatal clinic,Visit,HES Specialty,Visit,
+visit_occurrence,visit_concept_id,32588,Premature Delivery,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,38004271,Psychiatric Hospital Unit,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32586,Readmission to Same Home Health Agency,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32606,Regular Discharge with Follow-up,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,38004272,Rehabilitation Hospital Unit,Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,32055,Religious Non-medical Health Care Inst-Outpatient Services@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32277,Residential Facility,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32174,Residential Facility@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32181,Residential Facility@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32176,Residential Facility@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32175,Residential Facility@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32177,Residential Facility@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32182,Residential Facility@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32178,Residential Facility@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32173,Residential Facility@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32184,Residential Facility@Replacement of Prior Abbreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32179,Residential Facility@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32180,Residential Facility@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32183,Residential Facility@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,38004319,"Residential Treatment Facilities, Psychiatric Residential Treatment Facility",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,38004320,"Residential Treatment Facilities, Substance Abuse Rehabilitation Facility",Visit,NUCC,Visit,
+visit_occurrence,visit_concept_id,44777683,Respite care,Visit,HES Specialty,Visit,
+visit_occurrence,visit_concept_id,32607,Return Transfer,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32589,Sick Baby,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,38004516,Skilled Nursing Facility,Visit,Medicare Specialty,Visit,
+visit_occurrence,visit_concept_id,32350,Skilled Nursing-Inpatient (Includes Medicare Part A)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32356,Skilled Nursing-Inpatient (Includes Medicare Part A)@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32352,Skilled Nursing-Inpatient (Includes Medicare Part A)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32351,Skilled Nursing-Inpatient (Includes Medicare Part A)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32353,Skilled Nursing-Inpatient (Includes Medicare Part A)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32357,Skilled Nursing-Inpatient (Includes Medicare Part A)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32349,Skilled Nursing-Inpatient (Includes Medicare Part A)@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32354,Skilled Nursing-Inpatient (Includes Medicare Part A)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32355,Skilled Nursing-Inpatient (Includes Medicare Part A)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32256,Skilled Nursing-Inpatient (Medicare Part B Only),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32358,Skilled Nursing-Inpatient (Medicare Part B Only)@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32360,Skilled Nursing-Inpatient (Medicare Part B Only)@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32359,Skilled Nursing-Inpatient (Medicare Part B Only)@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32361,Skilled Nursing-Inpatient (Medicare Part B Only)@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32364,Skilled Nursing-Inpatient (Medicare Part B Only)@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32362,Skilled Nursing-Inpatient (Medicare Part B Only)@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32363,Skilled Nursing-Inpatient (Medicare Part B Only)@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32366,Skilled Nursing-Outpatient@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32372,Skilled Nursing-Outpatient@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32371,Skilled Nursing-Outpatient@Final Claim for a Home Health PPS Episode,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32368,Skilled Nursing-Outpatient@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32367,Skilled Nursing-Outpatient@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32369,Skilled Nursing-Outpatient@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32373,Skilled Nursing-Outpatient@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32365,Skilled Nursing-Outpatient@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32370,Skilled Nursing-Outpatient@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32374,Skilled Nursing-Outpatient@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32186,Special Facility - Other@Admit through Discharge Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32397,Special Facility - Other@CWF Initiated Adjustment Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32188,Special Facility - Other@Interim-Cont claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32187,Special Facility - Other@Interim-first claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32189,Special Facility - Other@Interim-last claim (b),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32398,Special Facility - Other@Intermediary Adjustment Claim (Other than QIO or Provider),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32190,Special Facility - Other@Late Charges Only,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32185,Special Facility - Other@Non-Payment/Zero,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32400,Special Facility - Other@Replacement of Prior Abbreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32191,Special Facility - Other@Replacement of Prior Claim,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32192,Special Facility - Other@Void/ Cancel of Prior claim (a),Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32399,Special Facility - Other@Void/Cance a Prior Abreviated Encounter Submission,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32278,Special Facility-Other,Visit,UB04 Typ bill,Visit,
+visit_occurrence,visit_concept_id,32220,Still patient,Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_concept_id,32585,Transfer From Another Home Health Agency,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32196,"Transfer from Skilled nursing facility, Intermediate care facility, Assisted living facility",Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32195,"Transfer from a Hospital, different facility",Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32201,Transfer from ambulatory care center,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32197,Transfer from another Healthcare facility,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32584,Transfer from critial access hospital,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32202,Transfer from hospice,Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32200,"Transfer within hospital, but seperate claim",Visit,UB04 Point of Origin,UB04 Point of Origin,
+visit_occurrence,visit_concept_id,32209,Unknown Value (but present in data),Visit,UB04 Pt dis status,UB04 Pt dis status,
+visit_occurrence,visit_type_concept_id,44818519,Clinical Study visit,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32034,Visit derived from EHR billing record,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32035,Visit derived from EHR encounter record,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,44818518,Visit derived from EHR record,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,44818517,Visit derived from encounter on claim,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32031,Visit derived from encounter on claim authorization,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32033,Visit derived from encounter on dental claim,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32021,Visit derived from encounter on medical claim,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32023,Visit derived from encounter on medical facility claim,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32027,Visit derived from encounter on medical facility claim deferred,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32026,Visit derived from encounter on medical facility claim denied,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32025,Visit derived from encounter on medical facility claim paid,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32024,Visit derived from encounter on medical professional claim,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32030,Visit derived from encounter on medical professional claim deferred,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32029,Visit derived from encounter on medical professional claim denied,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32028,Visit derived from encounter on medical professional claim paid,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32022,Visit derived from encounter on pharmacy claim,Type Concept,Visit Type,Visit Type,S
+visit_occurrence,visit_type_concept_id,32032,Visit derived from encounter on vision claim,Type Concept,Visit Type,Visit Type,S

--- a/rabbitinahat/src/main/resources/org/ohdsi/rabbitInAHat/dataModel/concept_id_hint_select.sql
+++ b/rabbitinahat/src/main/resources/org/ohdsi/rabbitInAHat/dataModel/concept_id_hint_select.sql
@@ -1,87 +1,251 @@
-SELECT vocabulary_version from @vocab.vocabulary WHERE vocabulary_id = 'None';
+-- SELECT vocabulary_version from @vocab.vocabulary WHERE vocabulary_id = 'None';
 
-SELECT 'person' AS omop_cdm_table, 'gender_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Gender'
-UNION ALL
-SELECT 'person' AS omop_cdm_table, 'ethnicity_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Ethnicity'
-UNION ALL
-SELECT 'person' AS omop_cdm_table, 'race_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Race'
-UNION ALL
-SELECT 'condition_occurrence' AS omop_cdm_table, 'condition_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Condition Type'
-UNION ALL
-SELECT 'cost' AS omop_cdm_table, 'cost_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Cost Type'
-UNION ALL
-SELECT 'death' AS omop_cdm_table, 'death_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Death Type'
-UNION ALL
-SELECT 'device_exposure' AS omop_cdm_table, 'device_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Device Type'
-UNION ALL
-SELECT 'drug_exposure' AS omop_cdm_table, 'drug_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Drug Type'
-UNION ALL
-SELECT 'episode' AS omop_cdm_table, 'episode_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Episode Type'
-UNION ALL
-SELECT 'measurement' AS omop_cdm_table, 'measurement_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Meas Type'
-UNION ALL
-SELECT 'note' AS omop_cdm_table, 'note_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Note Type'
-UNION ALL
-SELECT 'observation_period' AS omop_cdm_table, 'period_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Obs Period Type'
-UNION ALL
-SELECT 'observation' AS omop_cdm_table, 'observation_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Observation Type'
-UNION ALL
-SELECT 'procedure_occurrence' AS omop_cdm_table, 'procedure_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Procedure Type'
-UNION ALL
-SELECT 'specimen' AS omop_cdm_table, 'specimen_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Specimen Type'
-UNION ALL
-SELECT 'visit_occurrence' AS omop_cdm_table, 'visit_type_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Type Concept' AND concept_class_id = 'Visit Type'
-UNION ALL
-SELECT 'visit_occurrence' AS omop_cdm_table, 'visit_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Visit'
-UNION ALL
-SELECT 'cost' AS omop_cdm_table, 'cost_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Cost'
-UNION ALL
-SELECT 'payer_plan_period' AS omop_cdm_table, 'plan_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Plan'
-UNION ALL
-SELECT 'drug_exposure' AS omop_cdm_table, 'route_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Route'
-UNION ALL
-SELECT 'measurement' AS omop_cdm_table, 'operator_concept_id' AS omop_cdm_field, concept_id, concept_name, standard_concept, 'v5.0 12-MAR-18' AS vocabulary_version
-FROM @vocab.concept
-WHERE domain_id = 'Meas Value Operator'
-ORDER BY omop_cdm_table, omop_cdm_field, standard_concept, concept_name
+WITH concept_hints AS (
+    SELECT 'person'            AS omop_cdm_table,
+           'gender_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Gender'
+    UNION ALL
+    SELECT 'person'               AS omop_cdm_table,
+           'ethnicity_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Ethnicity'
+    UNION ALL
+    SELECT 'person'          AS omop_cdm_table,
+           'race_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Race'
+    UNION ALL
+    SELECT 'condition_occurrence'      AS omop_cdm_table,
+           'condition_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Condition Type'
+    UNION ALL
+    SELECT 'cost'                 AS omop_cdm_table,
+           'cost_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Cost Type'
+    UNION ALL
+    SELECT 'death'                 AS omop_cdm_table,
+           'death_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Death Type'
+    UNION ALL
+    SELECT 'device_exposure'        AS omop_cdm_table,
+           'device_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Device Type'
+    UNION ALL
+    SELECT 'drug_exposure'        AS omop_cdm_table,
+           'drug_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Drug Type'
+    UNION ALL
+    SELECT 'episode'                 AS omop_cdm_table,
+           'episode_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Episode Type'
+    UNION ALL
+    SELECT 'measurement'                 AS omop_cdm_table,
+           'measurement_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Meas Type'
+    UNION ALL
+    SELECT 'note'                 AS omop_cdm_table,
+           'note_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Note Type'
+    UNION ALL
+    SELECT 'observation_period'     AS omop_cdm_table,
+           'period_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Obs Period Type'
+    UNION ALL
+    SELECT 'observation'                 AS omop_cdm_table,
+           'observation_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Observation Type'
+    UNION ALL
+    SELECT 'procedure_occurrence'      AS omop_cdm_table,
+           'procedure_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Procedure Type'
+    UNION ALL
+    SELECT 'specimen'                 AS omop_cdm_table,
+           'specimen_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Specimen Type'
+    UNION ALL
+    SELECT 'visit_occurrence'      AS omop_cdm_table,
+           'visit_type_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Type Concept'
+      AND concept_class_id = 'Visit Type'
+    UNION ALL
+    SELECT 'visit_occurrence' AS omop_cdm_table,
+           'visit_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Visit'
+    UNION ALL
+    SELECT 'cost'            AS omop_cdm_table,
+           'cost_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Cost'
+    UNION ALL
+    SELECT 'payer_plan_period' AS omop_cdm_table,
+           'plan_concept_id'   AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Plan'
+    UNION ALL
+    SELECT 'drug_exposure'    AS omop_cdm_table,
+           'route_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Route'
+    UNION ALL
+    SELECT 'measurement'         AS omop_cdm_table,
+           'operator_concept_id' AS omop_cdm_field,
+           concept_id,
+           concept_name,
+           domain_id,
+           vocabulary_id,
+           concept_class_id,
+           standard_concept
+    FROM @vocab.concept
+    WHERE domain_id = 'Meas Value Operator'
+)
+SELECT *
+FROM concept_hints
+ORDER BY omop_cdm_table, omop_cdm_field, standard_concept, concept_name, domain_id, concept_class_id, vocabulary_id
 ;


### PR DESCRIPTION
In the cost_concept_id hints, there are a lot of pairs with the same concept name but different concept_id. This user has no hint which to choose.

This PR adds the concept_class_id of all concept id hints in rabbit in a hat

![image](https://user-images.githubusercontent.com/17825660/77004014-b0117d80-695e-11ea-978a-740e95463b10.png)
