### PR TITLE
Table overview in scan report

### DIFF
--- a/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Database.java
+++ b/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Database.java
@@ -182,10 +182,10 @@ public class Database implements Serializable {
 		return database;
 	}
 
-	public static Table createTable(String name, String comment, Integer nRows, Integer nRowsChecked) {
+	public static Table createTable(String name, String description, Integer nRows, Integer nRowsChecked) {
 		Table table = new Table();
 		table.setName(name.toLowerCase());
-		table.setComment(comment);
+		table.setDescription(description);
 		table.setRowCount((nRows == null || nRows == -1) ? nRowsChecked : nRows);
 		return table;
 	}

--- a/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Table.java
+++ b/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Table.java
@@ -24,6 +24,7 @@ public class Table implements MappableItem {
 
 	private Database			db;
 	private String				name;
+	private String				description			= "";
 	private int					rowCount;
 	private int					rowsCheckedCount;
 	private String				comment				= "";
@@ -69,6 +70,14 @@ public class Table implements MappableItem {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	public int getRowCount() {

--- a/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Table.java
+++ b/rabbit-core/src/main/java/org/ohdsi/rabbitInAHat/dataModel/Table.java
@@ -34,6 +34,11 @@ public class Table implements MappableItem {
 	public Table() {
 		super();
 	}
+
+	public Table(String name) {
+		super();
+		this.setName(name);
+	}
 	
 	public Table(Table table) {
 		super();

--- a/rabbit-core/src/main/java/org/ohdsi/utilities/ScanFieldName.java
+++ b/rabbit-core/src/main/java/org/ohdsi/utilities/ScanFieldName.java
@@ -18,4 +18,6 @@ public interface ScanFieldName {
     String Q2 = "Median";
     String Q3 = "75%";
     String MAX = "Max";
+    String N_FIELDS = "N Fields";
+    String N_FIELDS_EMPTY = "N Fields Empty";
 }

--- a/rabbit-core/src/main/java/org/ohdsi/utilities/ScanSheetName.java
+++ b/rabbit-core/src/main/java/org/ohdsi/utilities/ScanSheetName.java
@@ -1,0 +1,6 @@
+package org.ohdsi.utilities;
+
+public interface ScanSheetName {
+    String FIELD_OVERVIEW = "Field Overview"; // RiaH requires this is the first sheet in the workbook
+    String TABLE_OVERVIEW = "Table Overview";
+}

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
@@ -187,6 +187,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 		private static final long	serialVersionUID	= -4393026616049677944L;
 		private Table				table;
 		private JLabel				nameLabel			= new JLabel("");
+		private DescriptionTextArea description			= new DescriptionTextArea ("");
 		private JLabel				rowCountLabel		= new JLabel("");
 		private SimpleTableModel	fieldTable			= new SimpleTableModel("Field", "Type","Description");
 		private JTextArea			commentsArea		= new JTextArea();
@@ -197,17 +198,28 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			setLayout(new BorderLayout());
 
 			JPanel generalInfoPanel = new JPanel();
-			generalInfoPanel.setLayout(new GridLayout(0, 2));
+			generalInfoPanel.setLayout(new BorderLayout(5,5));
 			generalInfoPanel.setBorder(BorderFactory.createTitledBorder("General information"));
 
-			generalInfoPanel.add(new JLabel("Table name: "));
-			generalInfoPanel.add(nameLabel);
+			JPanel fieldInfo = new JPanel();
+			fieldInfo.setLayout(new GridLayout(0,2));
 
-			generalInfoPanel.add(new JLabel("Number of rows: "));
-			generalInfoPanel.add(rowCountLabel);
+			fieldInfo.add(new JLabel("Table name: "));
+			fieldInfo.add(nameLabel);
+
+			fieldInfo.add(new JLabel("Number of rows: "));
+			fieldInfo.add(rowCountLabel);
+
+			generalInfoPanel.add(fieldInfo, BorderLayout.NORTH);
+
+			JPanel descriptionInfo = new JPanel();
+			descriptionInfo.setLayout(new GridLayout(0,2));
+			descriptionInfo.add(new JLabel("Description: "));
+			descriptionInfo.add(description);
+			generalInfoPanel.add(descriptionInfo, BorderLayout.SOUTH);
+
 			add(generalInfoPanel, BorderLayout.NORTH);
 
-			
 			JScrollPane fieldListPanel = new JScrollPane(displayTable);
 			
 			// Updates row heights when column widths change
@@ -292,6 +304,10 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 		public void showTable(Table table) {
 			this.table = table;
 			nameLabel.setText(table.getName());
+			description.setText(table.getDescription());
+
+			// Hide description if it's empty
+			description.getParent().setVisible(!description.getText().isEmpty());
 
 			if (table.getRowCount() > 0) {
 				rowCountLabel.setText(numberFormat.format(table.getRowCount()));
@@ -368,8 +384,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			JPanel descriptionInfo = new JPanel();
 			descriptionInfo.setLayout(new GridLayout(0,2));
 			descriptionInfo.add(new JLabel("Description: "));
-			descriptionInfo.add(description);			
-			
+			descriptionInfo.add(description);
 			generalInfoPanel.add(descriptionInfo,BorderLayout.SOUTH);
 			
 			add(generalInfoPanel, BorderLayout.NORTH);
@@ -385,9 +400,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 				// Wide columns for concept name and class id
 				table.getColumnModel().getColumn(1).setPreferredWidth(300);
 				table.getColumnModel().getColumn(2).setPreferredWidth(100);
-			}
-
-			if (!isTargetFieldPanel) {
+			} else {
 				// Wide column for value name
 				table.getColumnModel().getColumn(0).setPreferredWidth(500);
 				// Right align the frequency and percentage
@@ -421,7 +434,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			rowCountLabel.setText(field.getType());
 			description.setText(field.getDescription());
 
-			// Hide description if it's empty, TODO: always show.
+			// Hide description if it's empty
 			description.getParent().setVisible(!description.getText().isEmpty());
 
 			this.createValueList(field);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/DetailsPanel.java
@@ -421,7 +421,7 @@ public class DetailsPanel extends JPanel implements DetailsListener {
 			rowCountLabel.setText(field.getType());
 			description.setText(field.getDescription());
 
-			// Hide description if it's empty
+			// Hide description if it's empty, TODO: always show.
 			description.getParent().setVisible(!description.getText().isEmpty());
 
 			this.createValueList(field);

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/RabbitInAHatMain.java
@@ -183,9 +183,14 @@ public class RabbitInAHatMain implements ResizeListener {
 
 		if (args.length == 1) {
 			doOpenSpecs(args[0]);
-		}
-		if (args.length > 1 && args[0].equals("-folder")) {
-			chooser = new JFileChooser(args[1]);
+		} else if (args.length > 1) {
+		   if (args[0].equals("--folder")) {
+			   chooser = new JFileChooser(args[1]);
+		   }
+
+		   if (args[0].equals("--scanReport")) {
+			   doOpenScanReport(args[1]);
+		   }
 		}
 	}
 
@@ -568,52 +573,56 @@ public class RabbitInAHatMain implements ResizeListener {
 	private void doOpenScanReport() {
 		String filename = chooseOpenPath(FILE_FILTER_XLSX);
 		if (filename != null) {
-			boolean replace = true;
-			if (ObjectExchange.etl.getSourceDatabase().getTables().size() != 0) {
-				Object[] options = { "Replace current data", "Load data on field values only" };
-				int result = JOptionPane.showOptionDialog(frame, "You already have source data loaded. Do you want to", "Replace source data?",
-						JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
-				if (result == -1)
-					return;
-				if (result == 1)
-					replace = false;
+			doOpenScanReport(filename);
+		}
+	}
+
+	private void doOpenScanReport(String filename) {
+		boolean replace = true;
+		if (ObjectExchange.etl.getSourceDatabase().getTables().size() != 0) {
+			Object[] options = { "Replace current data", "Load data on field values only" };
+			int result = JOptionPane.showOptionDialog(frame, "You already have source data loaded. Do you want to", "Replace source data?",
+					JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[0]);
+			if (result == -1)
+				return;
+			if (result == 1)
+				replace = false;
+		}
+		frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+		if (replace) {
+			ETL etl = new ETL();
+			doRemoveStemTable();
+			try {
+				etl.setSourceDatabase(Database.generateModelFromScanReport(filename));
+				etl.setTargetDatabase(ObjectExchange.etl.getTargetDatabase());
+				tableMappingPanel.setMapping(etl.getTableToTableMapping());
+				ObjectExchange.etl = etl;
+			} catch (Exception e) {
+				e.printStackTrace();
+				JOptionPane.showMessageDialog(null, "Invalid File Format", "Error", JOptionPane.ERROR_MESSAGE);
 			}
-			frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-			if (replace) {
-				ETL etl = new ETL();
-				doRemoveStemTable();
-				try {
-					etl.setSourceDatabase(Database.generateModelFromScanReport(filename));
-					etl.setTargetDatabase(ObjectExchange.etl.getTargetDatabase());
-					tableMappingPanel.setMapping(etl.getTableToTableMapping());
-					ObjectExchange.etl = etl;
-				} catch (Exception e) {
-					e.printStackTrace();
-					JOptionPane.showMessageDialog(null, "Invalid File Format", "Error", JOptionPane.ERROR_MESSAGE);
-				}
-			} else {
-				try {
-					Database newData = Database.generateModelFromScanReport(filename);
-					Database oldData = ObjectExchange.etl.getSourceDatabase();
-					for (Table newTable : newData.getTables()) {
-						Table oldTable = (Table) findByName(newTable.getName(), oldData.getTables());
-						if (oldTable != null) {
-							for (Field newField : newTable.getFields()) {
-								Field oldField = (Field) findByName(newField.getName(), oldTable.getFields());
-								if (oldField != null) {
-									oldField.setValueCounts(newField.getValueCounts());
-								}
+		} else {
+			try {
+				Database newData = Database.generateModelFromScanReport(filename);
+				Database oldData = ObjectExchange.etl.getSourceDatabase();
+				for (Table newTable : newData.getTables()) {
+					Table oldTable = (Table) findByName(newTable.getName(), oldData.getTables());
+					if (oldTable != null) {
+						for (Field newField : newTable.getFields()) {
+							Field oldField = (Field) findByName(newField.getName(), oldTable.getFields());
+							if (oldField != null) {
+								oldField.setValueCounts(newField.getValueCounts());
 							}
 						}
 					}
-				} catch (Exception e) {
-					e.printStackTrace();
-					JOptionPane.showMessageDialog(null, "Invalid File Format", "Error", JOptionPane.ERROR_MESSAGE);
 				}
-
+			} catch (Exception e) {
+				e.printStackTrace();
+				JOptionPane.showMessageDialog(null, "Invalid File Format", "Error", JOptionPane.ERROR_MESSAGE);
 			}
-			frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+
 		}
+		frame.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
 	}
 
 	private MappableItem findByName(String name, List<? extends MappableItem> list) {

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
@@ -39,6 +39,7 @@ import org.ohdsi.databases.RichConnection.QueryResult;
 import org.ohdsi.rabbitInAHat.dataModel.Table;
 import org.ohdsi.utilities.DateUtilities;
 import org.ohdsi.utilities.ScanFieldName;
+import org.ohdsi.utilities.ScanSheetName;
 import org.ohdsi.utilities.StringUtilities;
 import org.ohdsi.utilities.collections.CountingSet;
 import org.ohdsi.utilities.collections.CountingSet.Count;
@@ -182,7 +183,7 @@ public class SourceDataScan {
 	}
 
 	private void createFieldOverviewSheet(SXSSFWorkbook workbook) {
-		Sheet overviewSheet = workbook.createSheet("Overview");
+		Sheet overviewSheet = workbook.createSheet(ScanSheetName.FIELD_OVERVIEW);
 		CellStyle percentageStyle = workbook.createCellStyle();
 		percentageStyle.setDataFormat(workbook.createDataFormat().getFormat("0.0%"));
 
@@ -267,9 +268,10 @@ public class SourceDataScan {
 	}
 
 	private void createTableOverviewSheet(SXSSFWorkbook workbook) {
-		Sheet tableOverviewSheet = workbook.createSheet("Table Overview");
+		Sheet tableOverviewSheet = workbook.createSheet(ScanSheetName.TABLE_OVERVIEW);
 
-		addRow(tableOverviewSheet,ScanFieldName.TABLE,
+		addRow(tableOverviewSheet,
+				ScanFieldName.TABLE, // TODO: for long table names, use name prefixed with index as in field overview
 				ScanFieldName.DESCRIPTION,
 				ScanFieldName.N_ROWS,
 				ScanFieldName.N_ROWS_CHECKED,
@@ -286,13 +288,14 @@ public class SourceDataScan {
 			long nFieldsEmpty = 0;
 			for (FieldInfo fieldInfo : tableToFieldInfos.get(table)) {
 				rowCount = max(rowCount, fieldInfo.rowCount);
-				rowCheckedCount = max(rowCheckedCount, fieldInfo.nProcessed);
+				rowCheckedCount = max(rowCheckedCount, fieldInfo.nProcessed); // TODO: how can there be a nProcessed without values scanned?
 				nFields += 1;
 				if (scanValues) {
 					nFieldsEmpty += fieldInfo.getFractionEmpty() == 1 ? 1 : 0;
 				}
 			}
-			addRow(tableOverviewSheet,tableName,
+			addRow(tableOverviewSheet,
+					tableName,
 					description,
 					rowCount,
 					rowCheckedCount,

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
@@ -159,28 +159,9 @@ public class SourceDataScan {
 		SXSSFWorkbook workbook = new SXSSFWorkbook(100); // keep 100 rows in memory, exceeding rows will be flushed to disk
 
 		sheetNameLookup = new HashMap<>();
-		createOverviewSheet(workbook, tableToFieldInfos);
+		createFieldOverviewSheet(workbook, tableToFieldInfos);
 
-		// Create table overview sheet
-		Sheet tableOverviewSheet = workbook.createSheet("Table Overview");
-
-		// Table level summary statistics
-		addRow(tableOverviewSheet, "Table", "Alias", "Description", "N rows", "N rows checked", "N Fields", "N Fields Empty");
-		for (String tableName : tableToFieldInfos.keySet()) {
-			long rowCount = -1;
-			long rowCheckedCount = -1;
-			long nFields = 0;
-			long nFieldsEmpty = 0;
-			for (FieldInfo fieldInfo : tableToFieldInfos.get(tableName)) {
-				rowCount = max(rowCount, fieldInfo.rowCount);
-				rowCheckedCount = max(rowCheckedCount, fieldInfo.nProcessed);
-				nFields += 1;
-				if (scanValues) {
-					nFieldsEmpty += fieldInfo.getFractionEmpty() == 1 ? 1 : 0;
-				}
-			}
-			addRow(tableOverviewSheet, tableName, "", "", rowCount, rowCheckedCount, nFields, scanValues ? nFieldsEmpty : "");
-		}
+		createTableOverviewSheet(workbook, tableToFieldInfos);
 
 		if (scanValues) {
 			createValueSheet(workbook, tableToFieldInfos);
@@ -195,7 +176,7 @@ public class SourceDataScan {
 		}
 	}
 
-	private void createOverviewSheet(SXSSFWorkbook workbook, Map<String, List<FieldInfo>> tableToFieldInfos) {
+	private void createFieldOverviewSheet(SXSSFWorkbook workbook, Map<String, List<FieldInfo>> tableToFieldInfos) {
 		Sheet overviewSheet = workbook.createSheet("Overview");
 		CellStyle percentageStyle = workbook.createCellStyle();
 		percentageStyle.setDataFormat(workbook.createDataFormat().getFormat("0.0%"));
@@ -276,6 +257,41 @@ public class SourceDataScan {
 				}
 			}
 			addRow(overviewSheet, "");
+		}
+	}
+
+	private void createTableOverviewSheet(SXSSFWorkbook workbook, Map<String, List<FieldInfo>> tableToFieldInfos) {
+		Sheet tableOverviewSheet = workbook.createSheet("Table Overview");
+
+		addRow(tableOverviewSheet,ScanFieldName.TABLE,
+				ScanFieldName.DESCRIPTION,
+				ScanFieldName.N_ROWS,
+				ScanFieldName.N_ROWS_CHECKED,
+				ScanFieldName.N_FIELDS,
+				ScanFieldName.N_FIELDS_EMPTY
+		);
+
+		for (String tableName : tableToFieldInfos.keySet()) {
+			long rowCount = -1;
+			long rowCheckedCount = -1;
+			long nFields = 0;
+			long nFieldsEmpty = 0;
+			String description = ""; // TODO
+			for (FieldInfo fieldInfo : tableToFieldInfos.get(tableName)) {
+				rowCount = max(rowCount, fieldInfo.rowCount);
+				rowCheckedCount = max(rowCheckedCount, fieldInfo.nProcessed);
+				nFields += 1;
+				if (scanValues) {
+					nFieldsEmpty += fieldInfo.getFractionEmpty() == 1 ? 1 : 0;
+				}
+			}
+			addRow(tableOverviewSheet,tableName,
+					description,
+					rowCount,
+					rowCheckedCount,
+					nFields,
+					scanValues ? nFieldsEmpty : ""
+			);
 		}
 	}
 

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
@@ -297,7 +297,7 @@ public class SourceDataScan {
 					rowCount,
 					rowCheckedCount,
 					nFields,
-					scanValues ? nFieldsEmpty : ""
+					scanValues ? nFieldsEmpty : -1
 			);
 		}
 	}


### PR DESCRIPTION
Generates an additional 'Table overview' sheet in the WhiteRabbit ScanReport, with the name of the tables in the scan and some statistics. For SAS files this also includes a short description of the tables. 
![image](https://user-images.githubusercontent.com/17825660/80527965-7b4d0900-8995-11ea-8019-3b76b371925d.png)

Rabbit in a Hat displays these table descriptions in a new description field.
![image](https://user-images.githubusercontent.com/17825660/80528104-ae8f9800-8995-11ea-9ad1-753ae52ef9b8.png)

