### PR TITLE
Riah source table details

### DIFF
--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -46,10 +46,7 @@ import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 
 import org.ohdsi.rabbitInAHat.Arrow.HighlightStatus;
-import org.ohdsi.rabbitInAHat.dataModel.ItemToItemMap;
-import org.ohdsi.rabbitInAHat.dataModel.MappableItem;
-import org.ohdsi.rabbitInAHat.dataModel.Mapping;
-import org.ohdsi.rabbitInAHat.dataModel.Table;
+import org.ohdsi.rabbitInAHat.dataModel.*;
 import org.ohdsi.utilities.collections.IntegerComparator;
 
 public class MappingPanel extends JPanel implements MouseListener, MouseMotionListener {
@@ -161,20 +158,22 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 		sourceComponents.clear();
 		cdmComponents.clear();
 		arrows.clear();
-		for (MappableItem item : mapping.getSourceItems())
+		for (MappableItem item : mapping.getSourceItems()) {
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
 					sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					sourceComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(255, 128, 0)));
 			}
-		for (MappableItem item : mapping.getTargetItems())
+		}
+		for (MappableItem item : mapping.getTargetItems()) {
 			if (!showOnlyConnectedItems || isConnected(item)) {
 				if (item.isStem())
 					cdmComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(160, 0, 160)));
 				else
 					cdmComponents.add(new LabeledRectangle(0, 400, ITEM_WIDTH, ITEM_HEIGHT, item, new Color(128, 128, 255)));
 			}
+		}
 		for (ItemToItemMap map : mapping.getSourceToTargetMaps()) {
 			Arrow component = new Arrow(getComponentWithItem(map.getSourceItem(), sourceComponents), getComponentWithItem(map.getTargetItem(), cdmComponents),
 					map);
@@ -756,13 +755,11 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				detailsListener.showDetails(component.getItem(), isSourceComponent);
 				repaint();
 
-				if (event.getClickCount() == 2) {
+				if (event.getClickCount() == 2 && isSourceComponent && !component.getItem().isStem()) {
 					if (slaveMappingPanel != null) {
+						// Create dummy mapping
 						slaveMappingPanel.setMapping(
-								ObjectExchange.etl.getFieldToFieldMapping(
-										(Table) component.getItem(),
-										new Table() // Show empty table
-								)
+								new Mapping<>(((Table) component.getItem()).getFields(), new ArrayList<>(), new ArrayList<>())
 						);
 						// Zoom arrow has to be set, but will not be shown
 						zoomArrow = new Arrow(

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -756,31 +756,26 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				detailsListener.showDetails(component.getItem(), isSourceComponent);
 				repaint();
 
-				// WIP
-				// TODO: This now shows a (random) target table. Allow to enter field view with only source or only target table.
-				// TODO: make display of fields independent of (zoom)Arrow.
-				// TODO: hide target CDM table ('source exploration mode')
 				if (event.getClickCount() == 2) {
 					if (slaveMappingPanel != null) {
 						slaveMappingPanel.setMapping(
 								ObjectExchange.etl.getFieldToFieldMapping(
 										(Table) component.getItem(),
-										(Table) components.get(0).getItem()
+										new Table() // Show empty table
 								)
 						);
+						// Zoom arrow has to be set, but will not be shown
 						zoomArrow = new Arrow(
 								component,
-								components.get(0)
+								components.get(0) // random target for the arrow
 						);
 
-						System.out.println("Clicked twice! Setting slaveMappingPanel");
 						new AnimateThread(true).start();
 
 						slaveMappingPanel.filterComponents("", false);
 						slaveMappingPanel.filterComponents("", true);
 					}
 				}
-				// End WIP
 				break;
 			}
 		}

--- a/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
+++ b/rabbitinahat/src/main/java/org/ohdsi/rabbitInAHat/MappingPanel.java
@@ -755,6 +755,32 @@ public class MappingPanel extends JPanel implements MouseListener, MouseMotionLi
 				boolean isSourceComponent = sourceComponents.contains(component);
 				detailsListener.showDetails(component.getItem(), isSourceComponent);
 				repaint();
+
+				// WIP
+				// TODO: This now shows a (random) target table. Allow to enter field view with only source or only target table.
+				// TODO: make display of fields independent of (zoom)Arrow.
+				// TODO: hide target CDM table ('source exploration mode')
+				if (event.getClickCount() == 2) {
+					if (slaveMappingPanel != null) {
+						slaveMappingPanel.setMapping(
+								ObjectExchange.etl.getFieldToFieldMapping(
+										(Table) component.getItem(),
+										(Table) components.get(0).getItem()
+								)
+						);
+						zoomArrow = new Arrow(
+								component,
+								components.get(0)
+						);
+
+						System.out.println("Clicked twice! Setting slaveMappingPanel");
+						new AnimateThread(true).start();
+
+						slaveMappingPanel.filterComponents("", false);
+						slaveMappingPanel.filterComponents("", true);
+					}
+				}
+				// End WIP
 				break;
 			}
 		}


### PR DESCRIPTION
Allow retrieving the field list of source table without the need of making a table to table mapping, by double clicking the source table. The field details page will not show a target:

![image](https://user-images.githubusercontent.com/17825660/82646834-8f42fe00-9c15-11ea-82a3-1f2e0e3a3f06.png)
