### PR TITLE
Bugfix to scan all rows for csv and sas files

### DIFF
--- a/rabbit-core/src/main/java/org/ohdsi/utilities/StringUtilities.java
+++ b/rabbit-core/src/main/java/org/ohdsi/utilities/StringUtilities.java
@@ -871,5 +871,31 @@ public class StringUtilities {
 		}
 		return false;
 	}
-	
+
+	public static int numericOptionToInt(String option) {
+		switch (option) {
+			case "100":
+			case "1 hundred":
+				return 100;
+			case "1,000":
+			case "1 thousand":
+				return 1000;
+			case "10,000":
+			case "10 thousand":
+				return 10000;
+			case "100,000":
+			case "100 thousand":
+				return 100000;
+			case "500,000":
+			case "500 thousand":
+				return 500000;
+			case "1,000,000":
+			case "1 million":
+				return 1000000;
+			case "all":
+				return -1;
+			default:
+				return 0;
+		}
+	}
 }

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/WhiteRabbitMain.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/WhiteRabbitMain.java
@@ -454,7 +454,7 @@ public class WhiteRabbitMain implements ActionListener {
 		scanOptionsTopPanel.add(Box.createHorizontalGlue());
 
 		scanOptionsTopPanel.add(new JLabel("Max distinct values "));
-		scanValuesCount = new JComboBox<>(new String[] { "100", "1,000", "10,000" });
+		scanValuesCount = new JComboBox<>(new String[] { "100", "1,000", "10,000", "100,000" });
 		scanValuesCount.setSelectedIndex(1);
 		scanValuesCount.setToolTipText("Maximum number of distinct values per field to be reported");
 		scanOptionsTopPanel.add(scanValuesCount);
@@ -478,7 +478,7 @@ public class WhiteRabbitMain implements ActionListener {
 		scanOptionsLowerPanel.add(Box.createHorizontalGlue());
 
 		scanOptionsLowerPanel.add(new JLabel("Numeric stats reservoir size: "));
-		numericStatsSampleSize = new JComboBox<>(new String[] { "100,000", "500,000", "1 million"});
+		numericStatsSampleSize = new JComboBox<>(new String[] { "100,000", "500,000", "1 million" });
 		numericStatsSampleSize.setSelectedIndex(0);
 		numericStatsSampleSize.setToolTipText("Maximum number of rows used to calculate numeric statistics");
 		scanOptionsLowerPanel.add(numericStatsSampleSize);
@@ -971,31 +971,10 @@ public class WhiteRabbitMain implements ActionListener {
 					return;
 			}
 		}
-		int rowCount = 0;
-		if (scanRowCount.getSelectedItem().toString().equals("100,000"))
-			rowCount = 100000;
-		else if (scanRowCount.getSelectedItem().toString().equals("500,000"))
-			rowCount = 500000;
-		else if (scanRowCount.getSelectedItem().toString().equals("1 million"))
-			rowCount = 1000000;
-		if (scanRowCount.getSelectedItem().toString().equals("all"))
-			rowCount = -1;
 
-		int valuesCount = 0;
-		if (scanValuesCount.getSelectedItem().toString().equals("100"))
-			valuesCount = 100;
-		else if (scanValuesCount.getSelectedItem().toString().equals("1,000"))
-			valuesCount = 1000;
-		else if (scanValuesCount.getSelectedItem().toString().equals("10,000"))
-			valuesCount = 10000;
-
-		int numStatsSamplerSize = 0;
-		if (numericStatsSampleSize.getSelectedItem().toString().equals("100,000"))
-			numStatsSamplerSize = 100000;
-		else if (numericStatsSampleSize.getSelectedItem().toString().equals("500,000"))
-			numStatsSamplerSize = 500000;
-		else if (numericStatsSampleSize.getSelectedItem().toString().equals("1 million"))
-			numStatsSamplerSize = 1000000;
+		int rowCount = StringUtilities.numericOptionToInt(scanRowCount.getSelectedItem().toString());
+		int valuesCount = StringUtilities.numericOptionToInt(scanValuesCount.getSelectedItem().toString());
+		int numStatsSamplerSize = StringUtilities.numericOptionToInt(numericStatsSampleSize.getSelectedItem().toString());
 
 		ScanThread scanThread = new ScanThread(
 				rowCount,

--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
@@ -72,6 +72,7 @@ public class SourceDataScan {
 
 
 	public void setSampleSize(int sampleSize) {
+		// -1 if sample size is not restricted
 		this.sampleSize = sampleSize;
 	}
 
@@ -554,7 +555,7 @@ public class SourceDataScan {
 					}
 				}
 			}
-			if (lineNr > sampleSize)
+			if (sampleSize != -1 && lineNr > sampleSize)
 				break;
 		}
 		for (FieldInfo fieldInfo : fieldInfos)
@@ -583,7 +584,7 @@ public class SourceDataScan {
 			return fieldInfos;
 		}
 
-		for (int lineNr = 0; lineNr < sasFileProperties.getRowCount() && lineNr < sampleSize; lineNr++) {
+		for (int lineNr = 0; lineNr < sasFileProperties.getRowCount(); lineNr++) {
 			Object[] row = sasFileReader.readNext();
 
 			if (row.length != fieldInfos.size()) {
@@ -594,6 +595,9 @@ public class SourceDataScan {
 			for (int i = 0; i < row.length; i++) {
 				fieldInfos.get(i).processValue(row[i] == null ? "" : row[i].toString());
 			}
+
+			if (sampleSize != -1 && lineNr >= sampleSize)
+				break;
 		}
 
 		for (FieldInfo fieldInfo : fieldInfos) {


### PR DESCRIPTION
Fixes #267 where, for csv and sas scans, selecting scanning 'all' rows caused no rows to be scanned.
