### PR TITLE
Fix poi issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.ohdsi</groupId>
     <artifactId>leporidae</artifactId>
     <packaging>pom</packaging>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.10.6-SNAPSHOT</version>
     <modules>
         <module>rabbitinahat</module>
         <module>whiterabbit</module>

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leporidae</artifactId>
         <groupId>org.ohdsi</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.10.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.23</version>
+            <version>8.0.25</version>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>
@@ -40,27 +40,27 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.0.0</version>
+            <version>3.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.0.0</version>
+            <version>3.17</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-excelant</artifactId>
-            <version>5.0.0</version>
+            <version>3.17</version>
         </dependency>
         <dependency>
-            <groupId>stax</groupId>
-            <artifactId>stax-api</artifactId>
-            <version>1.0.1</version>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml-schemas</artifactId>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>5.0.1</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>20030203.000129</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -40,27 +40,27 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>3.17</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>3.17</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-excelant</artifactId>
-            <version>3.17</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml-schemas</artifactId>
-            <version>3.9</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>2.3.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -37,6 +37,7 @@
             <artifactId>dom4j</artifactId>
             <version>2.1.3</version>
         </dependency>
+        <!-- Note: Apache poi v5.x is current incompatible with the QuickAndDirtyXLSReader-->
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
@@ -57,6 +58,7 @@
             <artifactId>poi-ooxml-schemas</artifactId>
             <version>4.1.2</version>
         </dependency>
+        <!-- Note: Apache xmlbeans v4.x and v5.x is incompatible with Apache poi v4-->
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
@@ -65,12 +67,12 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.19</version>
+            <version>42.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.cedarsoftware</groupId>
             <artifactId>json-io</artifactId>
-            <version>4.12.0</version>
+            <version>4.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -80,7 +82,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <version>20030203.000129</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
@@ -90,12 +92,12 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.5.1</version>
+            <version>2.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.healthmarketscience.jackcess</groupId>
             <artifactId>jackcess</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>net.sf.ucanaccess</groupId>
@@ -105,7 +107,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.1.0.1</version>
+            <version>2.1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.teradata.jdbc</groupId>

--- a/rabbit-core/src/main/java/org/ohdsi/ooxml/ReadXlsxFileWithHeader.java
+++ b/rabbit-core/src/main/java/org/ohdsi/ooxml/ReadXlsxFileWithHeader.java
@@ -83,7 +83,7 @@ public class ReadXlsxFileWithHeader implements Iterable<Row> {
 			List<String> cells = new ArrayList<String>(fieldName2ColumnIndex.size());
 			for (Cell cell : iterator.next()) {
 				String text;
-				if (cell.getCellType().equals(CellType.NUMERIC))
+				if (cell.getCellTypeEnum() == CellType.NUMERIC)
 					text = myFormatter.format(cell.getNumericCellValue());
 				else
 					text = cell.toString();

--- a/rabbitinahat/pom.xml
+++ b/rabbitinahat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leporidae</artifactId>
         <groupId>org.ohdsi</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.10.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/whiterabbit/pom.xml
+++ b/whiterabbit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leporidae</artifactId>
         <groupId>org.ohdsi</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.10.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Fixes #316 by reverting to v4.x of the Apache POI libraries.

This fixes three functionalities that were broken since v0.10.4:
* Opening scan report in RiaH
* Generating fake data with WR from scan report
* Generating Word export of mapping specification in RiaH
