### PR TITLE
Fix POM definitions for mvn dependency:tree to work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <repository>
             <id>clojars</id>
             <name>Clojars Repository</name>
-            <url>http://clojars.org/repo/</url>
+            <url>https://clojars.org/repo/</url>
             <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>
@@ -38,24 +38,6 @@
             <id>icm</id>
             <name>ICM Repository</name>
             <url>https://maven.ceon.pl/artifactory/</url>
-            <layout>default</layout>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>mulesoft</id>
-            <name>Mulesoft Repository</name>
-            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
-            <layout>default</layout>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>jahia</id>
-            <name>Geomajas Repository</name>
-            <url>http://maven.geomajas.org/</url>
             <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -17,11 +17,12 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc14</artifactId>
-            <version>10.2.0.1.0</version>
-        </dependency>
+	 <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8-production</artifactId>
+	    <version>21.1.0.0</version>
+	    <type>pom</type>
+	 </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>sqljdbc4</artifactId>

--- a/rabbitinahat/pom.xml
+++ b/rabbitinahat/pom.xml
@@ -41,6 +41,7 @@
             <groupId>org.ohdsi</groupId>
             <artifactId>rabbit-core</artifactId>
             <version>${project.version}</version>
+	    <type>pom</type>
         </dependency>
     </dependencies>
 </project>

--- a/whiterabbit/pom.xml
+++ b/whiterabbit/pom.xml
@@ -41,6 +41,7 @@
             <groupId>org.ohdsi</groupId>
             <artifactId>rabbit-core</artifactId>
             <version>${project.version}</version>
+	    <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Previous dependency definitions cause maven errors.