### PR TITLE
docs: fixes overlapped header

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,6 @@
+body {
+  margin-top: 60px;
+}
 .rmdimportant {
   padding: 1em 1em 1em 4em;
   margin-bottom: 10px;


### PR DESCRIPTION
**Before**
<img width="1068" alt="Screen Shot 2022-05-13 at 15 43 15" src="https://user-images.githubusercontent.com/1716463/168226269-969d9fa4-93df-4ea3-bb73-173c5011f248.png">

**After**
<img width="957" alt="Screen Shot 2022-05-13 at 15 42 04" src="https://user-images.githubusercontent.com/1716463/168226133-856cba47-2581-49b6-8f8b-4928e4d92d37.png">

