### PR TITLE
Enforce english locale when writing unique fraction cells

### DIFF
--- a/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
+++ b/whiterabbit/src/main/java/org/ohdsi/whiteRabbit/scan/SourceDataScan.java
@@ -254,7 +254,7 @@ public class SourceDataScan {
 							fieldInfo.nProcessed,
 							fieldInfo.getFractionEmpty(),
 							fieldInfo.hasValuesTrimmed() ? String.format("<= %d", uniqueCount) : uniqueCount,
-							fieldInfo.hasValuesTrimmed() ? String.format("<= %.3f", fractionUnique) : fractionUnique
+							fieldInfo.hasValuesTrimmed() ? String.format(Locale.ENGLISH, "<= %.3f", fractionUnique) : fractionUnique
 					));
 					if (calculateNumericStats) {
 						values.addAll(Arrays.asList(


### PR DESCRIPTION
This is the easiest way to fix #367, i guess.