### PR TITLE
Update deps java8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 target/
 *.class
 
+# jenv file(s)
+.java-version
+
 # Repo specific ignores
 /ScanReport.xlsx
 *swp

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -28,8 +28,8 @@
             <version>4.0</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>8.0.32</version>
         </dependency>
         <dependency>

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -30,28 +30,46 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.25</version>
+            <version>8.0.32</version>
         </dependency>
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
         </dependency>
         <!-- Note: Apache poi v5.x is current incompatible with the QuickAndDirtyXLSReader-->
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
             <version>4.1.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>4.1.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-excelant</artifactId>
             <version>4.1.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -67,17 +85,17 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.2</version>
+            <version>42.5.4</version>
         </dependency>
         <dependency>
             <groupId>com.cedarsoftware</groupId>
             <artifactId>json-io</artifactId>
-            <version>4.13.0</version>
+            <version>4.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
-            <version>1.9.0</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -92,12 +110,12 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.6.1</version>
+            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.healthmarketscience.jackcess</groupId>
             <artifactId>jackcess</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.5</version>
         </dependency>
         <dependency>
             <groupId>net.sf.ucanaccess</groupId>
@@ -107,7 +125,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.1.0.2</version>
+            <version>2.1.0.11</version>
         </dependency>
         <dependency>
             <groupId>com.teradata.jdbc</groupId>
@@ -204,5 +222,12 @@
             <artifactId>parso</artifactId>
             <version>2.0.14</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.ant/ant -->
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.13</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
Prior to a more elaborate update (snowflake support, java 11, update of dependencies that require java 11) this will be the last dependency update for the current version of WhiteRabbit.