### PR TITLE
Update version (and fix mvn site config)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,4 +21,4 @@ It comes with **RabbitInAHat**, an application for interactive design of an ETL 
 - Rabbit in a Hat generates ETL specification document according to OMOP templatement according to OMOP template
 
 # Latest version
-[**v0.10.7**](https://github.com/OHDSI/WhiteRabbit/releases/latest)
+[**v0.10.8**](https://github.com/OHDSI/WhiteRabbit/releases/latest)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.ohdsi</groupId>
     <artifactId>leporidae</artifactId>
     <packaging>pom</packaging>
-    <version>0.10.7</version>
+    <version>0.10.8</version>
     <modules>
         <module>rabbitinahat</module>
         <module>whiterabbit</module>
@@ -135,6 +135,16 @@
                         </fileset>
                     </filesets>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.0.0</version>
             </plugin>
         </plugins>
 

--- a/rabbit-core/pom.xml
+++ b/rabbit-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leporidae</artifactId>
         <groupId>org.ohdsi</groupId>
-        <version>0.10.7</version>
+        <version>0.10.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rabbitinahat/pom.xml
+++ b/rabbitinahat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leporidae</artifactId>
         <groupId>org.ohdsi</groupId>
-        <version>0.10.7</version>
+        <version>0.10.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/whiterabbit/pom.xml
+++ b/whiterabbit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leporidae</artifactId>
         <groupId>org.ohdsi</groupId>
-        <version>0.10.7</version>
+        <version>0.10.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Release 0.10.8

- dependencies updated as far as possible with java 8
- plugins added to fix `mvn site`